### PR TITLE
board: Add configuration for the Orange Pi Win+

### DIFF
--- a/board/orangepi_win_plus
+++ b/board/orangepi_win_plus
@@ -1,0 +1,1 @@
+PLATFORM=sun50i


### PR DESCRIPTION
Adds configuration for Orange Pi Win Plus board.