### PR TITLE
project: Update file header copyright messages

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -24,7 +24,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ## BSD 3-clause License
 
     Copyright © 2013-2017, ARM Limited and Contributors. All rights reserved.
-    Copyright © 2017 Samuel Holland <samuel@sholland.org>
+    Copyright © 2017-2018 The Crust Firmware Authors.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2017 Samuel Holland <samuel@sholland.org>
+# Copyright © 2017-2018 The Crust Firmware Authors.
 # SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
 #
 

--- a/common/console.S
+++ b/common/console.S
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/common/debug.c
+++ b/common/debug.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/common/dm.c
+++ b/common/dm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/common/exception.c
+++ b/common/exception.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/common/main.c
+++ b/common/main.c
@@ -1,6 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
- * Copyright © 2017 Drew Walters <drewwalters96@gmail.com>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/common/panic.S
+++ b/common/panic.S
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/common/start.S
+++ b/common/start.S
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/common/vectors.S
+++ b/common/vectors.S
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/common/work.c
+++ b/common/work.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Drew Walters <drewwalters96@gmail.com>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/drivers/clock/sunxi-ccu.c
+++ b/drivers/clock/sunxi-ccu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/drivers/irqchip/irqchip.c
+++ b/drivers/irqchip/irqchip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/drivers/irqchip/sun4i-intc.c
+++ b/drivers/irqchip/sun4i-intc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/drivers/msgbox/sunxi-msgbox.c
+++ b/drivers/msgbox/sunxi-msgbox.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/arch/exception.h
+++ b/include/arch/exception.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/byteswap.h
+++ b/include/byteswap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/console.h
+++ b/include/console.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/ctype.h
+++ b/include/ctype.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2005-2014 Rich Felker, et al.
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: MIT
  */
 

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/dm.h
+++ b/include/dm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/drivers/clock.h
+++ b/include/drivers/clock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/drivers/clock/sunxi-ccu.h
+++ b/include/drivers/clock/sunxi-ccu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/drivers/irqchip.h
+++ b/include/drivers/irqchip.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/drivers/irqchip/sun4i-intc.h
+++ b/include/drivers/irqchip/sun4i-intc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/drivers/msgbox.h
+++ b/include/drivers/msgbox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/drivers/msgbox/sunxi-msgbox.h
+++ b/include/drivers/msgbox/sunxi-msgbox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/error.h
+++ b/include/error.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/exception.h
+++ b/include/exception.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/limits.h
+++ b/include/limits.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2005-2014 Rich Felker, et al.
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/macros.S
+++ b/include/macros.S
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2013-2017, ARM Limited and Contributors. All rights reserved.
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/include/mmio.h
+++ b/include/mmio.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2013-2014, ARM Limited and Contributors. All rights reserved.
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: BSD-3-Clause
  */
 

--- a/include/spr.h
+++ b/include/spr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/stdarg.h
+++ b/include/stdarg.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2005-2014 Rich Felker, et al.
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/stdbool.h
+++ b/include/stdbool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/stddef.h
+++ b/include/stddef.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2005-2014 Rich Felker, et al.
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/stdint.h
+++ b/include/stdint.h
@@ -1,6 +1,6 @@
 /*
  * Copyright © 2005-2014 Rich Felker, et al.
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/string.h
+++ b/include/string.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/util.h
+++ b/include/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/include/work.h
+++ b/include/work.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Drew Walters <drewwalters96@gmail.com>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/lib/runtime.S
+++ b/lib/runtime.S
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/lib/string.c
+++ b/lib/string.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/platform/sun50i/devices.c
+++ b/platform/sun50i/devices.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/platform/sun50i/include/platform/ccu.h
+++ b/platform/sun50i/include/platform/ccu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/platform/sun50i/include/platform/devices.h
+++ b/platform/sun50i/include/platform/devices.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/platform/sun50i/include/platform/irq.h
+++ b/platform/sun50i/include/platform/irq.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/platform/sun50i/include/platform/memory.h
+++ b/platform/sun50i/include/platform/memory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 

--- a/scripts/scp.ld.S
+++ b/scripts/scp.ld.S
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2012-2017 Samuel Holland <samuel@sholland.org>
+ * Copyright © 2017-2018 The Crust Firmware Authors.
  * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
  */
 


### PR DESCRIPTION
This commit adds "Crust Firmware Authors" to the file header copyright notices.

Closes #29

Signed-off-by: Drew Walters <drewwalters96@gmail.com>