### PR TITLE
common: Use circular buffer for work queue

### DIFF
--- a/common/work.c
+++ b/common/work.c
@@ -17,45 +17,82 @@ static struct {
 	void         *param;
 } work_items[MAX_WORK_ITEMS];
 
+static size_t queue_head = 0;
+static size_t queue_tail = MAX_WORK_ITEMS;
+
+/**
+ * Determine if the queue is empty using the given arguments. The values of
+ * the head and tail range from 0 to 2 * MAX_WORK_ITEMS. This allows us to
+ * distinguish between a full queue or an empty queue if the head is equal to
+ * the tail or if the head and tail are exactly MAX_WORK_ITEMS elements apart,
+ * respectively.
+ *
+ * @param  head The index of the head of the work_items queue.
+ * @param  tail The index of the tail of the work_items queue.
+ * @return      True if the queue is empty, otherwise false.
+ */
+static inline bool
+queue_empty(size_t head, size_t tail)
+{
+	return (head + MAX_WORK_ITEMS) % (2 * MAX_WORK_ITEMS) == tail;
+}
+
+/**
+ * Determine if the queue is full using the given arguments.
+ *
+ * @param  head The index of the head of the work_items queue.
+ * @param  tail The index of the tail of the work_items queue.
+ * @return      True if the queue is full, otherwise false.
+ */
+static inline bool
+queue_full(size_t head, size_t tail)
+{
+	return head == tail;
+}
+
+/**
+ * Find the next value of the given queue head or tail.
+ *
+ * @param  head The index of the head or tail of the work_items queue.
+ * @return      The next value of the queue head or tail.
+ */
+static inline size_t
+queue_next(size_t i)
+{
+	return (i + 1) % (2 * MAX_WORK_ITEMS);
+}
+
 void
 process_work(void)
 {
-	bool found_work;
-
-	do {
-		found_work = false;
-		/* Execute work items in the queue. */
-		for (size_t i = 0; i < MAX_WORK_ITEMS; ++i) {
-			if (work_items[i].fn != NULL) {
-				found_work = true;
-				work_items[i].fn(work_items[i].param);
-				work_items[i].fn = NULL;
-			}
-		}
-	} while (found_work);
+	/* Walk the queue. */
+	while (!queue_empty(queue_head, queue_tail)) {
+		size_t i = queue_head % MAX_WORK_ITEMS;
+		work_items[i].fn(work_items[i].param);
+		queue_head = queue_next(queue_head);
+	}
 }
 
 void
 queue_work(work_function fn, void *param)
 {
-	bool queued = false;
+	size_t i;
 
-	/* Find first available index and verify work item is not queued. */
-	for (size_t i = 0; i < MAX_WORK_ITEMS; ++i) {
-		if (!queued && work_items[i].fn == NULL) {
-			queued = true;
-			work_items[i].fn    = fn;
-			work_items[i].param = param;
-		} else if (work_items[i].fn == fn &&
-		           work_items[i].param == param) {
-			if (queued) {
-				/* Remove duplicate work item from queue. */
-				work_items[i].fn = NULL;
-			}
+	/* Walk the queue and check for duplicates. */
+	for (i = queue_head; !queue_empty(i, queue_tail); i = queue_next(i)) {
+		if (work_items[i % MAX_WORK_ITEMS].fn == fn &&
+		    work_items[i % MAX_WORK_ITEMS].param == param) {
+			debug("(%p, %p) is already in the work queue",
+			      (void *)(uintptr_t)fn, param);
 			return;
 		}
 	}
 
-	if (!queued)
+	if (queue_full(queue_head, queue_tail))
 		panic("Work queue is full");
+
+	/* Add the work item to the tail of the queue. */
+	work_items[queue_tail % MAX_WORK_ITEMS].fn    = fn;
+	work_items[queue_tail % MAX_WORK_ITEMS].param = param;
+	queue_tail = queue_next(queue_tail);
 }


### PR DESCRIPTION
Allows us to execute work in the order that it is added to the queue.

Signed-off-by: Christopher Wong <cwong164@gmail.com>