### PR TITLE
common: Implement a delay function using the wallclock

### DIFF
--- a/common/delay.c
+++ b/common/delay.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017-2018 The Crust Firmware Authors.
+ * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ */
+
+#include <delay.h>
+#include <stdint.h>
+#include <drivers/wallclock.h>
+
+void
+delay_cycles(uint32_t cycles)
+{
+	uint64_t start = wallclock_read();
+
+	/* If no wallclock driver is loaded, the read value won't change. */
+	if (start == 0)
+		return;
+
+	while (wallclock_read() < start + cycles) {
+		/* Wait for time to pass. */
+	}
+}

--- a/include/delay.h
+++ b/include/delay.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2017-2018 The Crust Firmware Authors.
+ * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ */
+
+#ifndef DELAY_H
+#define DELAY_H
+
+#include <stdint.h>
+
+/**
+ * Spin (do nothing) for at least the given number of reference clock (24MHz)
+ * cycles.
+ *
+ * @param The number of cycles to delay for.
+ */
+void delay_cycles(uint32_t cycles);
+
+#endif /* DELAY_H */


### PR DESCRIPTION
This is useful for hardware where we can't change registers too fast.
For example, both the CCU and R_TIMER devices require delays in between
two register updates. In these cases, the delay required is much too
short for the overhead of a timer interrupt to be worth using the timer
framework.

Both #75 and #63 have been rebased on top of this PR.