### PR TITLE
Message box updates

### DIFF
--- a/drivers/msgbox/sunxi-msgbox.c
+++ b/drivers/msgbox/sunxi-msgbox.c
@@ -34,23 +34,23 @@
 #define XMIT_MSG_DATA_REG(n)    (0x0184 + 0x8 * (n))
 #define RECV_MSG_DATA_REG(n)    (0x0180 + 0x8 * (n))
 
-static inline msg_handler
+static inline msgbox_handler
 get_handler(struct device *dev, uint8_t chan)
 {
-	return ((msg_handler *)dev->drvdata)[chan];
+	return ((msgbox_handler *)dev->drvdata)[chan];
 }
 
 static inline void
-set_handler(struct device *dev, uint8_t chan, msg_handler handler)
+set_handler(struct device *dev, uint8_t chan, msgbox_handler handler)
 {
-	((msg_handler *)dev->drvdata)[chan] = handler;
+	((msgbox_handler *)dev->drvdata)[chan] = handler;
 }
 
 static void
 sunxi_msgbox_handle_msg(struct device *dev, uint8_t chan)
 {
-	msg_handler handler;
-	uint32_t    msg = mmio_read32(dev->regs + RECV_MSG_DATA_REG(chan));
+	msgbox_handler handler;
+	uint32_t msg = mmio_read32(dev->regs + RECV_MSG_DATA_REG(chan));
 
 	if ((handler = get_handler(dev, chan)))
 		handler(dev, chan, msg);
@@ -77,7 +77,7 @@ sunxi_msgbox_irq(struct device *dev)
 
 static int
 sunxi_msgbox_register_handler(struct device *dev, uint8_t chan,
-                              msg_handler handler)
+                              msgbox_handler handler)
 {
 	assert(chan < SUNXI_MSGBOX_CHANS);
 	assert(handler);

--- a/include/drivers/msgbox.h
+++ b/include/drivers/msgbox.h
@@ -11,17 +11,18 @@
 
 #define MSGBOX_OPS(dev) ((struct msgbox_driver_ops *)((dev)->drv->ops))
 
-typedef void (*msg_handler)(struct device *dev, uint8_t chan, uint32_t msg);
+typedef void (*msgbox_handler)(struct device *dev, uint8_t chan, uint32_t msg);
 
 struct msgbox_driver_ops {
 	int (*register_handler)(struct device *dev, uint8_t chan,
-	                        msg_handler handler);
+	                        msgbox_handler handler);
 	int (*send_msg)(struct device *dev, uint8_t chan, uint32_t msg);
 	int (*unregister_handler)(struct device *dev, uint8_t chan);
 };
 
 static inline int
-msgbox_register_handler(struct device *dev, uint8_t chan, msg_handler handler)
+msgbox_register_handler(struct device *dev, uint8_t chan,
+                        msgbox_handler handler)
 {
 	return MSGBOX_OPS(dev)->register_handler(dev, chan, handler);
 }

--- a/include/drivers/msgbox.h
+++ b/include/drivers/msgbox.h
@@ -7,6 +7,7 @@
 #define DRIVERS_MSGBOX_H
 
 #include <dm.h>
+#include <stdbool.h>
 #include <stdint.h>
 
 #define MSGBOX_OPS(dev) ((struct msgbox_driver_ops *)((dev)->drv->ops))
@@ -14,10 +15,11 @@
 typedef void (*msgbox_handler)(struct device *dev, uint8_t chan, uint32_t msg);
 
 struct msgbox_driver_ops {
-	int (*register_handler)(struct device *dev, uint8_t chan,
-	                        msgbox_handler handler);
-	int (*send_msg)(struct device *dev, uint8_t chan, uint32_t msg);
-	int (*unregister_handler)(struct device *dev, uint8_t chan);
+	int  (*register_handler)(struct device *dev, uint8_t chan,
+	                         msgbox_handler handler);
+	int  (*send_msg)(struct device *dev, uint8_t chan, uint32_t msg);
+	bool (*tx_pending)(struct device *dev, uint8_t chan);
+	int  (*unregister_handler)(struct device *dev, uint8_t chan);
 };
 
 static inline int
@@ -31,6 +33,12 @@ static inline int
 msgbox_send_msg(struct device *dev, uint8_t chan, uint32_t msg)
 {
 	return MSGBOX_OPS(dev)->send_msg(dev, chan, msg);
+}
+
+static inline bool
+msgbox_tx_pending(struct device *dev, uint8_t chan)
+{
+	return MSGBOX_OPS(dev)->tx_pending(dev, chan);
 }
 
 static inline int

--- a/include/drivers/msgbox.h
+++ b/include/drivers/msgbox.h
@@ -22,6 +22,14 @@ struct msgbox_driver_ops {
 	int  (*unregister_handler)(struct device *dev, uint8_t chan);
 };
 
+/**
+ * Register a handler to be called when messages are received on a message box
+ * channel.
+ *
+ * @param dev     The message box device.
+ * @param chan    The message box channel.
+ * @param handler The callback function to register.
+ */
 static inline int
 msgbox_register_handler(struct device *dev, uint8_t chan,
                         msgbox_handler handler)
@@ -29,18 +37,40 @@ msgbox_register_handler(struct device *dev, uint8_t chan,
 	return MSGBOX_OPS(dev)->register_handler(dev, chan, handler);
 }
 
+/**
+ * Send a message via a message box device.
+ *
+ * @param dev  The message box device.
+ * @param chan The channel to use within the message box.
+ * @param msg  The message to send.
+ */
 static inline int
 msgbox_send_msg(struct device *dev, uint8_t chan, uint32_t msg)
 {
 	return MSGBOX_OPS(dev)->send_msg(dev, chan, msg);
 }
 
+/**
+ * Check if a previous transmission on a message box channel is still pending.
+ * A message is pending until the reception IRQ has been cleared on the remote
+ * interface.
+ *
+ * @param dev  The message box device.
+ * @param chan    The message box channel.
+ */
 static inline bool
 msgbox_tx_pending(struct device *dev, uint8_t chan)
 {
 	return MSGBOX_OPS(dev)->tx_pending(dev, chan);
 }
 
+/**
+ * Unregister a message handler, so it will no longer be called for new
+ * messages on a message box channel.
+ *
+ * @param dev     The message box device.
+ * @param chan    The message box channel.
+ */
 static inline int
 msgbox_unregister_handler(struct device *dev, uint8_t chan)
 {

--- a/include/drivers/msgbox/sunxi-msgbox.h
+++ b/include/drivers/msgbox/sunxi-msgbox.h
@@ -18,7 +18,7 @@
 #define SUNXI_MSGBOX_CHANS 4
 
 #define SUNXI_MSGBOX_DRVDATA \
-	(uintptr_t)&(msg_handler[SUNXI_MSGBOX_CHANS])
+	(uintptr_t)&(msgbox_handler[SUNXI_MSGBOX_CHANS])
 
 extern const struct driver sunxi_msgbox_driver;
 


### PR DESCRIPTION
This was one of the first drivers I wrote, and I wrote a Linux driver for the same hardware afterward. Update this driver to match current practices (e.g. `0` → `SUCCESS`) and match the Linux driver more closely. Finally, add a new feature to the msgbox class that's needed for SCPI support.