### PR TITLE
drivers: irqchip: Add assertions to the irqchip framework

### DIFF
--- a/drivers/irqchip/irqchip.c
+++ b/drivers/irqchip/irqchip.c
@@ -8,15 +8,17 @@
 #include <error.h>
 #include <irqchip.h>
 #include <spr.h>
+#include <stddef.h>
 
-static struct device *irqchip_device;
+static struct device *irqchip;
 
 int
 irqchip_device_register(struct device *dev)
 {
-	if (irqchip_device)
+	if (irqchip != NULL)
 		return EEXIST;
-	irqchip_device = dev;
+
+	irqchip = dev;
 
 	/* Enable the CPU external interrupt input. */
 	mtspr(SPR_SYS_SR_ADDR, SPR_SYS_SR_IEE_SET(mfspr(SPR_SYS_SR_ADDR), 1));
@@ -27,8 +29,7 @@ irqchip_device_register(struct device *dev)
 int
 irqchip_irq(void)
 {
-	if (!irqchip_device)
-		panic("Interrupt with no irqchip registered");
+	assert(irqchip != NULL);
 
-	return IRQCHIP_OPS(irqchip_device)->irq(irqchip_device);
+	return IRQCHIP_OPS(irqchip)->irq(irqchip);
 }

--- a/include/drivers/irqchip.h
+++ b/include/drivers/irqchip.h
@@ -6,6 +6,7 @@
 #ifndef DRIVERS_IRQCHIP_H
 #define DRIVERS_IRQCHIP_H
 
+#include <debug.h>
 #include <dm.h>
 #include <stdint.h>
 
@@ -33,6 +34,8 @@ irqchip_register_irq(struct device *dev, irq_handler handler)
 {
 	struct device *irqdev = dev->irqdev;
 
+	assert(irqdev);
+
 	return IRQCHIP_OPS(irqdev)->register_irq(irqdev, dev, handler);
 }
 
@@ -40,6 +43,8 @@ static inline int
 irqchip_unregister_irq(struct device *dev)
 {
 	struct device *irqdev = dev->irqdev;
+
+	assert(irqdev);
 
 	return IRQCHIP_OPS(irqdev)->unregister_irq(irqdev, dev);
 }


### PR DESCRIPTION
This brings the irqchip device class in line with improvements
previously made to the clock and wallclock classes. The header
assertions catch devices missing initialization of their irqdev member.
The irqchip.c changes simplify the file, removing a large string for a
case that cannot happen unless irqchip_irq() is called somewhere other
than an IRQ handler.