### PR TITLE
Correctly synchronize shared data structures

### DIFF
--- a/include/common/interrupts.h
+++ b/include/common/interrupts.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017-2018 The Crust Firmware Authors.
+ * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ */
+
+#ifndef COMMON_INTERRUPTS_H
+#define COMMON_INTERRUPTS_H
+
+#include <compiler.h>
+#include <spr.h>
+#include <stdint.h>
+
+/**
+ * Disable interrupts and provide a compiler barrier. The return value must be
+ * saved and passed to restore_interrupts() at the end of the critical section.
+ */
+static inline uint32_t __must_check
+disable_interrupts(void)
+{
+	uint32_t mask = SPR_SYS_SR_IEE_MASK | SPR_SYS_SR_TEE_MASK;
+	uint32_t reg  = mfspr(SPR_SYS_SR_ADDR);
+
+	mtspr(SPR_SYS_SR_ADDR, reg & ~mask);
+
+	return reg;
+}
+
+/**
+ * Restore interrupts and provide a compiler barrier.
+ *
+ * @param reg The register contents saved from a call to disable_interrupts().
+ */
+static inline void
+restore_interrupts(uint32_t reg)
+{
+	mtspr(SPR_SYS_SR_ADDR, reg);
+}
+
+#endif /* COMMON_INTERRUPTS_H */

--- a/include/lib/compiler.h
+++ b/include/lib/compiler.h
@@ -23,6 +23,9 @@
 #define always_inline     __attribute__((__always_inline__)) inline
 #define noinline          __attribute__((__noinline__))
 
+/* Barriers */
+#define barrier()         asm volatile ("" : : : "memory")
+
 /* Builtins */
 #define likely(e)         __builtin_expect(!!(e), 1)
 #define unlikely(e)       __builtin_expect(e, 0)


### PR DESCRIPTION
<!-- Thank you for contributing to Crust firmware!

Pull requests that do not follow the guidelines outlined in the Crust firmware
contribution guidelines are subject to immediate rejection! -->

## Purpose

Fix synchronization issues with the work queue and SCPI buffer list. These aren't easily visible until we start processing requests at high speed and they suddenly stop working.

## Considerations for reviewers

Any better names for the header or helper functions? They aren't _really_ locks, as they just prevent preemption by interrupts; but since we're single-threaded, it's effectively the same.