### PR TITLE
CSS (Core Subsystem) API and generic implementation

### DIFF
--- a/common/css.c
+++ b/common/css.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2017-2018 The Crust Firmware Authors.
+ * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ */
+
+#include <compiler.h>
+#include <css.h>
+#include <debug.h>
+#include <error.h>
+#include <stdint.h>
+#include <util.h>
+
+/*
+ * These generic functions provide a safe default implementation of the CSS
+ * API, so platforms may implement power domain control functions
+ * incrementally. Platforms should implement the getters before the setters.
+ */
+
+/**
+ * Generic implementation used when no platform support is available. Because
+ * the generic setters prevent changing the CSS state, the CSS must always be
+ * running.
+ */
+uint8_t __weak
+css_get_css_state(void)
+{
+	/* Assume the CSS is always on. */
+	return POWER_STATE_ON;
+}
+
+/**
+ * Generic implementation used when no platform support is available. Assume
+ * the minimum possible number of clusters is present.
+ */
+uint8_t __weak
+css_get_cluster_count(void)
+{
+	/* Assume the CSS contains a single cluster with a single core. */
+	return 1;
+}
+
+/**
+ * Generic implementation used when no platform support is available. Because
+ * the generic setters prevent changing any cluster state, the set of running
+ * clusters is always equal to the set of clusters initialized by the boot ROM.
+ */
+uint8_t __weak
+css_get_cluster_state(uint8_t cluster __unused)
+{
+	/* Assume present clusters/cores are always on. */
+	if (cluster >= css_get_cluster_count())
+		return POWER_STATE_OFF;
+
+	return POWER_STATE_ON;
+}
+
+/**
+ * Generic implementation used when no platform support is available. Assume
+ * the minimum possible number of cores is present in each cluster.
+ */
+uint8_t __weak
+css_get_core_count(uint8_t cluster __unused)
+{
+	/* Assume the CSS contains a single cluster with a single core. */
+	return 1;
+}
+
+/**
+ * Generic implementation used when no platform support is available. Because
+ * the generic setters prevent changing any core state, the set of running
+ * cores is always equal to the set of cores initialized by the boot ROM.
+ */
+uint8_t __weak
+css_get_core_state(uint8_t cluster, uint8_t core)
+{
+	/* Assume present clusters/cores are always on. */
+	if (cluster >= css_get_cluster_count())
+		return POWER_STATE_OFF;
+	if (core >= css_get_core_count(cluster))
+		return POWER_STATE_OFF;
+
+	return POWER_STATE_ON;
+}
+
+/*
+ * There should usually be no reason to override this weak definition. It
+ * correctly implements the algorithm specified in the CSS API using the
+ * lower-level core state API. However, this definition is declared weak for
+ * consistency with the other functions and flexibility for future platforms.
+ */
+uint8_t __weak
+css_get_online_cores(uint8_t cluster)
+{
+	uint8_t cores;
+	uint8_t mask = 0;
+
+	assert(cluster < css_get_cluster_count());
+
+	cores = css_get_core_count(cluster);
+	for (uint8_t core = 0; core < cores; ++core) {
+		if (css_get_core_state(cluster, core) != POWER_STATE_OFF)
+			mask |= BIT(core);
+	}
+
+	return mask;
+}
+
+/**
+ * Generic implementation used when no platform support is available. Because
+ * the generic code does not know how to control the hardware, prohibit changes
+ * to the CSS state by default without a platform-specific implementation.
+ */
+int __weak
+css_set_css_state(uint8_t state)
+{
+	/* Reject any attempts to change CSS, cluster, or core power states. */
+	return state == css_get_css_state() ? SUCCESS : ENOTSUP;
+}
+
+/**
+ * Generic implementation used when no platform support is available. Because
+ * the generic code does not know how to control the hardware, prohibit changes
+ * to the cluster state by default without a platform-specific implementation.
+ */
+int __weak
+css_set_cluster_state(uint8_t cluster, uint8_t state)
+{
+	/* Reject any attempts to change CSS, cluster, or core power states. */
+	return state == css_get_cluster_state(cluster) ? SUCCESS : ENOTSUP;
+}
+
+/**
+ * Generic implementation used when no platform support is available. Because
+ * the generic code does not know how to control the hardware, prohibit changes
+ * to the core state by default without a platform-specific implementation.
+ */
+int __weak
+css_set_core_state(uint8_t cluster, uint8_t core, uint8_t state)
+{
+	/* Reject any attempts to change CSS, cluster, or core power states. */
+	return state == css_get_core_state(cluster, core) ? SUCCESS : ENOTSUP;
+}

--- a/include/common/css.h
+++ b/include/common/css.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2017-2018 The Crust Firmware Authors.
+ * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ */
+
+#ifndef COMMON_CSS_H
+#define COMMON_CSS_H
+
+#include <stdint.h>
+
+/**
+ * Possible CSS power domain states, matching those used in existing
+ * implementations of the SCPI protocol.
+ */
+enum {
+	POWER_STATE_ON  = 0,
+	POWER_STATE_OFF = 3,
+};
+
+/**
+ * Get the state of the compute subsystem (CSS).
+ */
+uint8_t css_get_css_state(void);
+
+/**
+ * Get the number of clusters in the compute subsystem.
+ *
+ * The number returned cannot be greater than 8.
+ */
+uint8_t css_get_cluster_count(void);
+
+/**
+ * Get the state of a cluster.
+ *
+ * @param cluster The index of the cluster.
+ */
+uint8_t css_get_cluster_state(uint8_t cluster);
+
+/**
+ * Get the number of cores present in a cluster.
+ *
+ * The number returned cannot be greater than 8.
+ *
+ * @param cluster The index of the cluster.
+ */
+uint8_t css_get_core_count(uint8_t cluster);
+
+/**
+ * Get the state of a CPU core.
+ *
+ * @param cluster The index of the cluster.
+ * @param core    The index of the core within the cluster.
+ */
+uint8_t css_get_core_state(uint8_t cluster, uint8_t core);
+
+/**
+ * Get a bitmask of the states of the cores in a cluster. A zero bit indicates
+ * that a core is completely off (i.e. it has no execution context, and must be
+ * manually woken up). Any other state is represented by a set bit.
+ *
+ * @param cluster The index of the cluster.
+ */
+uint8_t css_get_online_cores(uint8_t cluster);
+
+/**
+ * Set the state of the compute subsystem (CSS). This state must not be
+ * numbered higher than the lowest cluster state in the CSS.
+ *
+ * @param state The coordinated requested state for the CSS.
+ */
+int css_set_css_state(uint8_t state);
+
+/**
+ * Set the state of a cluster. This state must not be numbered lower than the
+ * CSS state, nor higher than the lowest core state for this cluster.
+ *
+ * @param cluster The index of the cluster.
+ * @param state   The coordinated requested state for the cluster.
+ */
+int css_set_cluster_state(uint8_t cluster, uint8_t state);
+
+/**
+ * Set the state of a CPU core. This state must not be numbered lower than the
+ * core's cluster state.
+ *
+ * @param cluster The index of the cluster.
+ * @param core    The index of the core within the cluster.
+ * @param state   The coordinated requested state for the CPU core.
+ */
+int css_set_core_state(uint8_t cluster, uint8_t core, uint8_t state);
+
+#endif /* COMMON_CSS_H */


### PR DESCRIPTION
## Purpose

This is the generic part of the CSS (core subsystem) code, and the respective SCPI integration. The actual platform-specific driver code is in a separate PR.

Closes #45.

## Considerations for reviewers

- I haven't added much documentation, but please sanity-check the structure of what I'm doing here. Does anything jump out as weird? I think I figured out the filenames once I realized CSS was the appropriate name here.
- ~~What do you think about using weak functions to provide a default implementation, but allow platforms to provide their own?~~
- ~~What about using functions to provide the number of clusters/cores? Theoretically it could be different between cores on some SoC, but it's not right now. Should I require platforms to supply macros instead? It shouldn't matter from a performance standpoint, because LTO should inline the functions as they are now.~~