### PR TITLE
SCPI: Fix buffer struct alignment issues

### DIFF
--- a/common/scpi.c
+++ b/common/scpi.c
@@ -29,7 +29,7 @@
 struct scpi_mem {
 	struct scpi_msg tx_msg; /**< The reply to be sent to a client. */
 	struct scpi_msg rx_msg; /**< The request received from a client. */
-} __packed;
+};
 
 struct scpi_buffer {
 	struct scpi_mem mem;    /**< Memory for the request/reply messages. */

--- a/include/common/scpi_protocol.h
+++ b/include/common/scpi_protocol.h
@@ -112,6 +112,6 @@ struct scpi_msg {
 	uint8_t  command;
 	uint32_t status;
 	uint32_t payload[SCPI_PAYLOAD_WORDS];
-} __packed;
+};
 
 #endif /* COMMON_SCPI_PROTOCOL_H */


### PR DESCRIPTION
Because they must match the SCPI ABI (the layout in memory), these
structs were marked as __packed to prevent GCC from inserting padding.
Unfortunately, that also causes GCC to consider them to have an
alignment of 1. Thus, when `struct scpi_mem` is put in `struct
scpi_buffer` along with two other bytes of data, there is no padding
added to the end of the structure. (There should be two bytes of padding
added, to match the correct alignment of 4). This then causes elements
of the `scpi_buffers` array to be misaligned, causing alignment faults.

Fix this by removing the __packed attribute, as the structures are
already laid out in a way that avoids padding between members. Then the
structures have the proper alignment, and padding is added at the end of
`struct scpi_buffer`.

## Purpose

Bug fix

Closes #106

## Considerations for reviewers

None