### PR TITLE
Makefile: Prevent accidentally introducing VLAs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ WARNINGS	 = -Wall -Wextra -Wformat=2 -Wpedantic -Wshadow \
 		   -Werror=pointer-arith \
 		   -Werror=pointer-sign \
 		   -Werror=strict-prototypes \
+		   -Werror=vla \
 		   -Wno-missing-field-initializers
 
 CFLAGS		 = -Os -pipe -std=c11 \


### PR DESCRIPTION
## Purpose

Tell GCC to produce an error if a variable-length array is used. They're
slow and insecure, and there's no need for them here.

This enhancement is prompted by VLA-removal changes going on in Linux at the moment.

## Considerations for reviewers

No VLAs are currently in use, nor was using them planned. This just makes that explicit.