### PR TITLE
Implement SCPI_CMD_SET_SYS_PWR

### DIFF
--- a/common/system_power.c
+++ b/common/system_power.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017-2018 The Crust Firmware Authors.
+ * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ */
+
+#include <compiler.h>
+#include <debug.h>
+#include <delay.h>
+#include <dm.h>
+#include <stddef.h>
+#include <watchdog.h>
+
+noreturn void
+system_reset(void)
+{
+	struct device *watchdog = dm_get_by_class(DM_CLASS_WATCHDOG);
+
+	if (watchdog != NULL) {
+		watchdog_disable(watchdog);
+		watchdog_enable(watchdog, 0);
+		udelay(1);
+	}
+	panic("Failed to reset system");
+}

--- a/include/common/system_power.h
+++ b/include/common/system_power.h
@@ -9,6 +9,15 @@
 #include <compiler.h>
 
 /**
+ * Possible system power states, matching those defined in the SCPI protocol.
+ */
+enum {
+	SYSTEM_POWER_STATE_SHUTDOWN = 0,
+	SYSTEM_POWER_STATE_REBOOT   = 1,
+	SYSTEM_POWER_STATE_RESET    = 2,
+};
+
+/**
  * Reset the SoC, including all CPU cores and internal peripheral devices.
  */
 noreturn void system_reset(void);

--- a/include/common/system_power.h
+++ b/include/common/system_power.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright © 2017-2018 The Crust Firmware Authors.
+ * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ */
+
+#ifndef COMMON_SYSTEM_POWER_H
+#define COMMON_SYSTEM_POWER_H
+
+#include <compiler.h>
+
+/**
+ * Reset the SoC, including all CPU cores and internal peripheral devices.
+ */
+noreturn void system_reset(void);
+
+#endif /* COMMON_SYSTEM_POWER_H */


### PR DESCRIPTION
## Purpose

Implements the SCPI command for shutting down or resetting the system. This allows PSCI to delegate to us, instead of reimplementing the functionality.

Closes #46 

## Considerations for reviewers

None