### PR TITLE
WIP: drivers: Update PIO driver API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CC		 = $(CROSS_COMPILE)gcc
 CPP		 = $(CROSS_COMPILE)cpp
 OBJCOPY		 = $(CROSS_COMPILE)objcopy
 
-WARNINGS	 = -Wall -Wextra -Wformat=2 -Wpedantic -Wshadow \
+WARNINGS	 = -Wall -Wextra -Wformat=2 -Wshadow \
 		   -Werror=implicit-function-declaration \
 		   -Werror=implicit-int \
 		   -Werror=pointer-arith \

--- a/drivers/gpio/gpio.c
+++ b/drivers/gpio/gpio.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017-2018 The Crust Firmware Authors.
+ * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ */
+
+#include <debug.h>
+#include <error.h>
+#include <gpio.h>
+#include <stddef.h>
+
+bool
+gpio_read_pin(struct device *dev, uint8_t pin)
+{
+	struct gpio_pins *gpio     = dev->gpio;
+	struct device    *gpio_dev = gpio->dev;
+	uint8_t pin_id;
+
+	assert(pin < gpio->count);
+
+	/* Retrieve the pin ID from the device specification. */
+	pin_id = gpio->pins[pin].id;
+
+	return GPIO_OPS(gpio_dev)->read_pin(gpio_dev, pin_id);
+}
+
+int
+gpio_set_pins(struct device *dev)
+{
+	struct gpio_pins *gpio = dev->gpio;
+	struct device    *gpio_dev = gpio->dev;
+	uint8_t num_pins, pin_id, mode;
+	int     result = EINVAL;
+
+	num_pins = gpio->count;
+	assert(num_pins > 0);
+
+	for (size_t p = 0; p < num_pins; ++p) {
+		pin_id = gpio->pins[p].id;
+		mode   = gpio->pins[p].mode;
+
+		if (GPIO_OPS(gpio_dev)->set_mode(gpio_dev, pin_id, mode))
+			break;
+	}
+
+	return result;
+}
+
+int
+gpio_write_pin(struct device *dev, uint8_t pin, bool val)
+{
+	struct gpio_pins *gpio     = dev->gpio;
+	struct device    *gpio_dev = gpio->dev;
+	uint8_t pin_id;
+
+	assert(pin < gpio->count);
+
+	/* Retrieve the pin ID from the device specification. */
+	pin_id = gpio->pins[pin].id;
+
+	return GPIO_OPS(gpio_dev)->write_pin(gpio_dev, pin_id, val);
+}

--- a/drivers/i2c/sun6i-a31-i2c.c
+++ b/drivers/i2c/sun6i-a31-i2c.c
@@ -11,6 +11,7 @@
 #include <i2c.h>
 #include <mmio.h>
 #include <util.h>
+#include <gpio/sunxi-gpio.h>
 
 #define I2C_ADDR_REG  0x00
 #define I2C_XADDR_REG 0x04
@@ -173,9 +174,8 @@ sun6i_a31_i2c_probe(struct device *dev)
 	if ((err = clock_enable(dev)))
 		return err;
 
-	/* Set port L pins 0-1 to I²C. */
-	gpio_set_mode(dev->bus, 0, 3);
-	gpio_set_mode(dev->bus, 1, 3);
+	/* Set pin modes specified in I2C device description. */
+	gpio_set_pins(dev);
 
 	/* Set I2C bus clock divider for 100 KHz operation. */
 	mmio_write32(dev->regs + I2C_CCR_REG, 0x00000011);

--- a/include/common/dm.h
+++ b/include/common/dm.h
@@ -22,7 +22,6 @@ enum {
 	DM_CLASS_I2C,
 	DM_CLASS_IRQCHIP,
 	DM_CLASS_MSGBOX,
-	DM_CLASS_PIO,
 	DM_CLASS_TIMER,
 	DM_CLASS_WATCHDOG,
 };
@@ -40,6 +39,8 @@ struct device {
 	uintptr_t                  drvdata;
 	/** The controller for the bus this device is connected to. */
 	struct device *const       bus;
+	/** Set of GPIO pins utilized by this device. */
+	struct gpio_pins          *gpio;
 	/** The controller for this device's clock. */
 	struct device *const       clockdev;
 	/** The controller for this device's IRQ. */

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -18,42 +18,37 @@ struct gpio_driver_ops {
 	int  (*write_pin)(struct device *dev, uint8_t pin, bool val);
 };
 
+struct gpio_pins {
+	struct device *dev; /**< The device that utilizes the GPIO pins. */
+	uint8_t        count;
+	struct {
+		uint8_t id;
+		uint8_t mode;
+	} pins[];
+};
+
 /**
  * Read the value of a pin.
  *
  * @param dev The port I/O device.
  * @param pin The index of the pin to retrieve the value for.
  */
-static inline bool
-gpio_read_pin(struct device *dev, uint8_t pin)
-{
-	return GPIO_OPS(dev)->read_pin(dev, pin);
-}
+bool gpio_read_pin(struct device *dev, uint8_t pin);
 
 /**
- * Set the mode of a pin.
+ * Sets the mode of all pins registered in the device description.
  *
  * @param dev  The port I/O device.
- * @param pin  The index of the pin to set the mode of.
- * @param mode The mode to set for the specified pin.
  */
-static inline int
-gpio_set_mode(struct device *dev, uint8_t pin, uint8_t mode)
-{
-	return GPIO_OPS(dev)->set_mode(dev, pin, mode);
-}
+int gpio_set_pins(struct device *dev);
 
 /**
  * Write the value of a pin.
  *
  * @param dev The port I/O device.
- * @param pin The pin to write a value to.
+ * @param pin The index of the pin in the device specification to write to.
  * @param val The value to write to the specified pin.
  */
-static inline int
-gpio_write_pin(struct device *dev, uint8_t pin, bool val)
-{
-	return GPIO_OPS(dev)->write_pin(dev, pin, val);
-}
+int gpio_write_pin(struct device *dev, uint8_t pin, bool val);
 
 #endif /* DRIVERS_GPIO_H */

--- a/platform/sun50i/devices.c
+++ b/platform/sun50i/devices.c
@@ -14,6 +14,7 @@
 #include <watchdog/sunxi-twd.h>
 #include <platform/ccu.h>
 #include <platform/devices.h>
+#include <platform/gpio.h>
 #include <platform/irq.h>
 #include <platform/r_ccu.h>
 
@@ -156,6 +157,7 @@ static struct device r_ccu = {
 
 static struct device r_i2c = {
 	.name     = "r_i2c",
+	.gpio     = &r_i2c_pins,
 	.regs     = DEV_R_I2C,
 	.drv      = &sun6i_a31_i2c_driver,
 	.bus      = &r_pio,
@@ -200,4 +202,13 @@ static struct device r_twd = {
 	.clock    = R_CCU_CLOCK_R_TWD,
 	.irqdev   = &r_intc,
 	.irq      = IRQ_R_TWD,
+};
+
+struct gpio_pins r_i2c_pins = {
+	.dev   = &r_i2c,
+	.count = 2,
+	.pins  = {
+		{ .id = 0, .mode = 3 },
+		{ .id = 1, .mode = 3 },
+	},
 };

--- a/platform/sun50i/include/platform/gpio.h
+++ b/platform/sun50i/include/platform/gpio.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright © 2017-2018 The Crust Firmware Authors.
+ * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ */
+
+#include <gpio.h>
+
+#ifndef PLATFORM_GPIO_H
+#define PLATFORM_GPIO_H
+
+extern struct gpio_pins r_i2c_pins;
+
+#endif /* PLATFORM_GPIO_H */


### PR DESCRIPTION
<!-- Thank you for contributing to Crust firmware!

Pull requests that do not follow the guidelines outlined in the Crust firmware
contribution guidelines are subject to immediate rejection! -->

## Purpose
<!-- Please include the purpose of changes included in this pull request. -->
- Standardize the PIO driver API, allowing it to use the pin controller as a bus.
- Move the pins utilized by a driver to its device description.
- Rename the `PIO` driver to `GPIO` driver.


<!-- Please add the issue number of the issue this pull request addresses. If
this pull request addresses multiple issues, please add them as a
comma-separated list (i.e. Closes #1, Closes #2, Fixes #3).

NOTE: when submitting a bug fix, please uses "Fixes" rather than "Closes" -->
Closes #105 

## Considerations for reviewers
<!-- (Optional) Include considerations or notes for project maintainers and
reviewers.  -->
- This does not work with the stub `axp` driver (but neither does the implementation in master on my hardware).
