### PR TITLE
Math library code (small header fix, signed division)

### DIFF
--- a/include/lib/math.h
+++ b/include/lib/math.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright © 2017-2018 The Crust Firmware Authors.
+ * SPDX-License-Identifier: (BSD-3-Clause OR GPL-2.0)
+ */
+
+#ifndef LIB_MATH_H
+#define LIB_MATH_H
+
+/**
+ * Count the number of set bits in an integer.
+ */
+#define popcount(x) __builtin_popcount(x)
+
+#endif /* LIB_MATH_H */

--- a/include/lib/util.h
+++ b/include/lib/util.h
@@ -17,9 +17,4 @@
 #define BIT(n)            (U(1) << (n))
 #define BITMASK(off, len) ((BIT(len) - 1) << (off))
 
-/**
- * Count the number of set bits in an integer.
- */
-#define popcount(x)       __builtin_popcount(x)
-
 #endif /* LIB_UTIL_H */

--- a/lib/runtime.S
+++ b/lib/runtime.S
@@ -5,6 +5,29 @@
 
 #include <macros.S>
 
+func __divsi3
+	l.sflts	r3, r0
+	l.sw	-8(r1), r2
+	l.bnf	1f
+	l.ori	r2, r0, 0
+	l.sub	r3, r0, r3		# Negate x if it is negative
+	l.addi	r2, r2, 1		# Increment the flag if x is negative
+1:	l.sflts	r4, r0
+	l.bnf	2f
+	l.sw	-4(r1), r9
+	l.sub	r4, r0, r4		# Negate y if it is negative
+	l.addi	r2, r2, -1		# Decrement the flag if y is negative
+2:	l.jal	__udivsi3
+	l.addi	r1, r1, -8
+	l.sfne	r2, r0
+	l.bnf	3f
+	l.addi	r1, r1, 8
+	l.sub	r11, r0, r11		# Negate q if the flag is nonzero
+3:	l.lwz	r9, -4(r1)
+	l.jr	r9
+	l.lwz	r2, -8(r1)
+endfunc __divsi3
+
 /*
  * Derived from the "best method for counting bits in a 32-bit integer" at
  * https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel.


### PR DESCRIPTION
## Purpose

Signed division is needed for regulators (calculating register values from voltage and vice versa).

## Considerations for reviewers

This blocks #114. This ideally should be merged before either #119 or #120.

This has been tested with lots of different values.