### PR TITLE
drivers: clock: Shrink the generic clock functions

### DIFF
--- a/drivers/clock/clock.c
+++ b/drivers/clock/clock.c
@@ -12,8 +12,9 @@
 int
 clock_disable(struct device *dev, uint8_t id)
 {
+	const struct clock_driver_ops *ops = CLOCK_OPS(dev);
 	struct clock_handle *parent;
-	struct clock_info   *info = clock_get_info(dev, id);
+	struct clock_info   *info = ops->get_info(dev, id);
 	int err;
 
 	/* Prevent disabling clocks that are critical or in use as parents. */
@@ -23,12 +24,12 @@ clock_disable(struct device *dev, uint8_t id)
 	}
 
 	/* Call the driver function to change the clock's state. */
-	if ((err = CLOCK_OPS(dev)->set_state(dev, id, false)))
+	if ((err = ops->set_state(dev, id, false)))
 		return err;
 
 	/* Mark the clock and its parent as no longer being in use. */
 	info->refcount--;
-	if ((parent = clock_get_parent(dev, id)) != NULL)
+	if ((parent = ops->get_parent(dev, id)) != NULL)
 		clock_get_info(parent->dev, parent->id)->refcount--;
 
 	return SUCCESS;
@@ -37,14 +38,15 @@ clock_disable(struct device *dev, uint8_t id)
 int
 clock_enable(struct device *dev, uint8_t id)
 {
+	const struct clock_driver_ops *ops = CLOCK_OPS(dev);
 	struct clock_handle *parent;
-	struct clock_info   *info = clock_get_info(dev, id);
+	struct clock_info   *info = ops->get_info(dev, id);
 	int err;
 	uint32_t rate;
 
 	/* Clamp the rate to the minimum/maximum rates and select a parent. */
 	if (!(info->flags & CLK_FIXED)) {
-		if ((err = clock_get_rate(dev, id, &rate)))
+		if ((err = ops->get_rate(dev, id, &rate)))
 			return err;
 		/* This will fail for fixed-rate or already-enabled clocks. */
 		if ((err = clock_set_rate(dev, id, rate)) && err != EPERM)
@@ -52,13 +54,13 @@ clock_enable(struct device *dev, uint8_t id)
 	}
 
 	/* Enable the parent clock, if it exists, and increase its refcount. */
-	if ((parent = clock_get_parent(dev, id)) != NULL) {
+	if ((parent = ops->get_parent(dev, id)) != NULL) {
 		if ((err = clock_enable(parent->dev, parent->id)))
 			return err;
 	}
 
 	/* Call the driver function to change the clock's state. */
-	if ((err = CLOCK_OPS(dev)->set_state(dev, id, true)))
+	if ((err = ops->set_state(dev, id, true)))
 		return err;
 
 	/* Mark the clock itself as being in use. */
@@ -70,8 +72,9 @@ clock_enable(struct device *dev, uint8_t id)
 int
 clock_get_state(struct device *dev, uint8_t id)
 {
+	const struct clock_driver_ops *ops = CLOCK_OPS(dev);
 	struct clock_handle *parent;
-	struct clock_info   *info = clock_get_info(dev, id);
+	struct clock_info   *info = ops->get_info(dev, id);
 	int err;
 
 	/* If this clock is in use, it must have been enabled. */
@@ -79,25 +82,26 @@ clock_get_state(struct device *dev, uint8_t id)
 		return true;
 
 	/* If the parent clock is disabled, this clock cannot be enabled. */
-	if ((parent = clock_get_parent(dev, id)) != NULL) {
+	if ((parent = ops->get_parent(dev, id)) != NULL) {
 		/* Propagate any error or a false return value. */
 		if ((err = clock_get_state(parent->dev, parent->id)) < true)
 			return err;
 	}
 
 	/* Call the driver function to read any gate this clock may have. */
-	return CLOCK_OPS(dev)->get_state(dev, id);
+	return ops->get_state(dev, id);
 }
 
 int
 clock_set_rate(struct device *dev, uint8_t id, uint32_t rate)
 {
-	struct clock_info *info = clock_get_info(dev, id);
+	const struct clock_driver_ops *ops = CLOCK_OPS(dev);
+	struct clock_info *info = ops->get_info(dev, id);
 
 	/* Prevent changing the rate of clocks that are fixed or are in use. */
 	if ((info->flags & CLK_FIXED) || (info->refcount > 0))
 		return EPERM;
 
 	/* Call the driver function to change the clock's rate. */
-	return CLOCK_OPS(dev)->set_rate(dev, id, rate);
+	return ops->set_rate(dev, id, rate);
 }


### PR DESCRIPTION
## Purpose

Reuse the driver ops pointer for calling driver functions where
appropriate. This saves ~56 bytes.

## Considerations for reviewers

No functional changes.