### PR TITLE
Fix regulator driver issues

### DIFF
--- a/drivers/regulator/axp803.c
+++ b/drivers/regulator/axp803.c
@@ -512,7 +512,7 @@ axp803_probe(struct device *dev)
 		return err;
 	if ((reg & IC_TYPE_MASK) != IC_TYPE_VALUE)
 		return ENODEV;
-	if (regulator_set_defaults(dev, (uint16_t *)dev->drvdata))
+	if ((err = regulator_set_defaults(dev, (uint16_t *)dev->drvdata)))
 		return err;
 
 	return SUCCESS;

--- a/drivers/regulator/regulator.c
+++ b/drivers/regulator/regulator.c
@@ -53,8 +53,15 @@ regulator_set_defaults(struct device *dev, uint16_t *values)
 	uint8_t count = ops->get_count(dev);
 
 	for (uint8_t id = 0; id < count; ++id) {
-		if ((err = regulator_set_value(dev, id, values[id])))
-			return err;
+		if (values[id] > 0) {
+			if ((err = regulator_set_value(dev, id, values[id])))
+				return err;
+			if ((err = regulator_enable(dev, id)))
+				return err;
+		} else {
+			if ((err = regulator_disable(dev, id)))
+				return err;
+		}
 	}
 
 	return SUCCESS;

--- a/drivers/regulator/sy8106a.c
+++ b/drivers/regulator/sy8106a.c
@@ -99,7 +99,7 @@ sy8106a_probe(struct device *dev)
 
 	if ((err = i2c_probe(dev->bus, dev->addr)))
 		return err;
-	if (regulator_set_defaults(dev, &default_value))
+	if ((err = regulator_set_defaults(dev, &default_value)))
 		return err;
 
 	return SUCCESS;

--- a/platform/sun50i/devices.c
+++ b/platform/sun50i/devices.c
@@ -43,10 +43,11 @@ static struct device axp803 = {
 	.drvdata = AXP803_DRVDATA {
 		[AXP803_REGL_DCDC1] = 3300,
 		[AXP803_REGL_DCDC2] = 1100,
-		/* DCDC3 is polyphased with DCDC2. */
+		[AXP803_REGL_DCDC3] = 1100,
 		/* DCDC4 is not connected. */
 		[AXP803_REGL_DCDC5] = 1500,
 		[AXP803_REGL_DCDC6] = 1100,
+		/* DC1SW is not connected. */
 		[AXP803_REGL_ALDO1] = 2800,
 		[AXP803_REGL_ALDO2] = 3300,
 		[AXP803_REGL_ALDO3] = 3000,
@@ -57,7 +58,7 @@ static struct device axp803 = {
 		[AXP803_REGL_ELDO1] = 1800,
 		/* ELDO2 is not connected. */
 		[AXP803_REGL_ELDO3] = 1800,
-		[AXP803_REGL_FLDO1] = 1200,
+		/* FLDO1 is connected but not used. */
 		[AXP803_REGL_FLDO2] = 1100,
 		/* GPIO0 is not connected. */
 		/* GPIO1 is not connected. */


### PR DESCRIPTION
## Purpose

Fixes possible failure to boot on devices with the AXP803 voltage regulator.

## Considerations for reviewers

Bugfix.