### PR TITLE
Allow multiple clocks per device

### DIFF
--- a/common/dm.c
+++ b/common/dm.c
@@ -168,22 +168,20 @@ dm_setup_clocks(struct device *dev, uint8_t num_clocks)
 int
 dm_setup_pins(struct device *dev, uint8_t num_pins)
 {
-	struct gpio_handle *pins = dev->gpio_pins;
-	struct device *gpio_dev;
-	uint8_t pin_id, mode;
-	int     err;
+	struct gpio_handle *pins = dev->pins;
+	int err;
 
-	for (size_t i = 0; i < num_pins; ++i) {
-		gpio_dev = pins[i].dev;
-		pin_id   = pins[i].pin;
-		mode     = pins[i].mode;
+	for (uint8_t i = 0; i < num_pins; ++i) {
+		struct device *gpiodev = pins[i].dev;
+		uint8_t id   = pins[i].pin;
+		uint8_t mode = pins[i].mode;
 
-		/* Probe to ensure GPIO controller is loaded. */
-		if ((err = device_probe(gpio_dev)))
+		/* Probe to ensure GPIO controller's driver is loaded. */
+		if ((err = device_probe(gpiodev)))
 			return err;
 
 		/* Set pin mode and return if error occurs. */
-		if ((err = gpio_set_mode(gpio_dev, pin_id, mode)))
+		if ((err = gpio_set_mode(gpiodev, id, mode)))
 			return err;
 	}
 

--- a/common/dm.c
+++ b/common/dm.c
@@ -40,8 +40,6 @@ device_probe(struct device *dev)
 	/* Probe all devices this device depends on. */
 	if (dev->bus && (err = device_probe(dev->bus)))
 		return err;
-	if (dev->clockdev && (err = device_probe(dev->clockdev)))
-		return err;
 	if (dev->irqdev && (err = device_probe(dev->irqdev)))
 		return err;
 	if (dev->supplydev && (err = device_probe(dev->supplydev)))

--- a/drivers/gpio/sunxi-gpio.c
+++ b/drivers/gpio/sunxi-gpio.c
@@ -69,7 +69,7 @@ sunxi_gpio_probe(struct device *dev)
 {
 	int err;
 
-	if ((err = clock_enable(dev->clockdev, dev->clock)))
+	if ((err = dm_setup_clocks(dev, 1)))
 		return err;
 
 	/* Disable and clear all IRQs. */

--- a/drivers/i2c/sun6i-a31-i2c.c
+++ b/drivers/i2c/sun6i-a31-i2c.c
@@ -163,7 +163,7 @@ sun6i_a31_i2c_probe(struct device *dev)
 {
 	int err;
 
-	if ((err = clock_enable(dev->clockdev, dev->clock)))
+	if ((err = dm_setup_clocks(dev, 1)))
 		return err;
 
 	/* Set port L pins 0-1 to I²C. */

--- a/drivers/msgbox/sunxi-msgbox.c
+++ b/drivers/msgbox/sunxi-msgbox.c
@@ -169,7 +169,7 @@ sunxi_msgbox_probe(struct device *dev)
 	/* Ensure a handler array was allocated. */
 	assert(dev->drvdata);
 
-	if ((err = clock_enable(dev->clockdev, dev->clock)))
+	if ((err = dm_setup_clocks(dev, 1)))
 		return err;
 
 	/* Drain all messages (required to clear interrupts). */

--- a/drivers/timer/sun8i-r_timer.c
+++ b/drivers/timer/sun8i-r_timer.c
@@ -73,7 +73,7 @@ sun8i_r_timer_probe(struct device *dev)
 	int err;
 	uintptr_t index = dev->drvdata;
 
-	if ((err = clock_enable(dev->clockdev, dev->clock)))
+	if ((err = dm_setup_clocks(dev, 1)))
 		return err;
 
 	/* Stop the timer and set it to 24MHz one-shot mode. */

--- a/drivers/watchdog/sunxi-twd.c
+++ b/drivers/watchdog/sunxi-twd.c
@@ -57,6 +57,11 @@ sunxi_twd_enable(struct device *dev, uint32_t timeout)
 static int
 sunxi_twd_probe(struct device *dev)
 {
+	int err;
+
+	if ((err = dm_setup_clocks(dev, 1)))
+		return err;
+
 	/* Disable watchdog. */
 	sunxi_twd_disable(dev);
 

--- a/include/common/dm.h
+++ b/include/common/dm.h
@@ -51,16 +51,12 @@ struct device {
 	struct clock_handle *const clocks;
 	/** The GPIO pins utilized by this device. */
 	struct gpio_handle *const  pins;
-	/** The controller for this device's clock. */
-	struct device *const       clockdev;
 	/** The controller for this device's IRQ. */
 	struct device *const       irqdev;
 	/** The controller for this device's power supply (regulator). */
 	struct device *const       supplydev;
 	/** A bus-specific address/port (if this device is on a bus). */
 	const uint8_t              addr;
-	/** A clockdev-specific clock identifier. */
-	const uint8_t              clock;
 	/** An irqdev-specific IRQ number. */
 	const uint8_t              irq;
 	/** A supplydev-specific power supply identifier. */

--- a/include/common/dm.h
+++ b/include/common/dm.h
@@ -50,7 +50,7 @@ struct device {
 	/** The clocks utilized by this device. */
 	struct clock_handle *const clocks;
 	/** The GPIO pins utilized by this device. */
-	struct gpio_handle        *gpio_pins;
+	struct gpio_handle *const  pins;
 	/** The controller for this device's clock. */
 	struct device *const       clockdev;
 	/** The controller for this device's IRQ. */
@@ -170,7 +170,7 @@ int dm_setup_clocks(struct device *dev, uint8_t num_clocks);
 /**
  * Set the mode of the GPIO pins specified for a device.
  *
- * @param dev       The device containing the GPIO pins to initialize.
+ * @param dev       The device referencing the GPIO pins to initialize.
  * @param num_pins  The number of pins utilized by the device.
  */
 int dm_setup_pins(struct device *dev, uint8_t num_pins);

--- a/include/common/dm.h
+++ b/include/common/dm.h
@@ -47,6 +47,8 @@ struct device {
 	uintptr_t                  drvdata;
 	/** The controller for the bus this device is connected to. */
 	struct device *const       bus;
+	/** The clocks utilized by this device. */
+	struct clock_handle *const clocks;
 	/** The GPIO pins utilized by this device. */
 	struct gpio_handle        *gpio_pins;
 	/** The controller for this device's clock. */
@@ -156,6 +158,14 @@ struct device *dm_next_subdev(struct device *dev, uint8_t *id);
  * panic.
  */
 void dm_init(void);
+
+/**
+ * Set up the clocks specified for a device.
+ *
+ * @param dev       The device referencing the clocks to initialize.
+ * @param num_pins  The number of clocks utilized by the device.
+ */
+int dm_setup_clocks(struct device *dev, uint8_t num_clocks);
 
 /**
  * Set the mode of the GPIO pins specified for a device.

--- a/platform/sun50i/devices.c
+++ b/platform/sun50i/devices.c
@@ -96,23 +96,21 @@ static struct device ccu = {
 };
 
 static struct device msgbox = {
-	.name     = "msgbox",
-	.regs     = DEV_MSGBOX,
-	.drv      = &sunxi_msgbox_driver.drv,
-	.drvdata  = SUNXI_MSGBOX_DRVDATA { 0 },
-	.clockdev = &ccu,
-	.clock    = CCU_CLOCK_MSGBOX,
-	.irqdev   = &r_intc,
-	.irq      = IRQ_MSGBOX,
+	.name    = "msgbox",
+	.regs    = DEV_MSGBOX,
+	.drv     = &sunxi_msgbox_driver.drv,
+	.drvdata = SUNXI_MSGBOX_DRVDATA { 0 },
+	.clocks  = CLOCK_PARENT(ccu, CCU_CLOCK_MSGBOX),
+	.irqdev  = &r_intc,
+	.irq     = IRQ_MSGBOX,
 };
 
 static struct device pio = {
-	.name     = "pio",
-	.regs     = DEV_PIO,
-	.drv      = &sunxi_gpio_driver.drv,
-	.drvdata  = BITMASK(1, 7), /**< Physically implemented ports (1-7). */
-	.clockdev = &ccu,
-	.clock    = CCU_CLOCK_PIO,
+	.name    = "pio",
+	.regs    = DEV_PIO,
+	.drv     = &sunxi_gpio_driver.drv,
+	.drvdata = BITMASK(1, 7), /**< Physically implemented ports (1-7). */
+	.clocks  = CLOCK_PARENT(ccu, CCU_CLOCK_PIO),
 };
 
 static struct device r_ccu = {
@@ -203,17 +201,16 @@ static struct device r_ccu = {
 };
 
 static struct device r_i2c = {
-	.name = "r_i2c",
-	.regs = DEV_R_I2C,
-	.drv  = &sun6i_a31_i2c_driver.drv,
-	.pins = GPIO_PINS(I2C_NUM_PINS) {
+	.name   = "r_i2c",
+	.regs   = DEV_R_I2C,
+	.drv    = &sun6i_a31_i2c_driver.drv,
+	.clocks = CLOCK_PARENT(r_ccu, R_CCU_CLOCK_R_I2C),
+	.pins   = GPIO_PINS(I2C_NUM_PINS) {
 		{ &r_pio, 0, 3 },
 		{ &r_pio, 1, 3 },
 	},
-	.clockdev = &r_ccu,
-	.clock    = R_CCU_CLOCK_R_I2C,
-	.irqdev   = &r_intc,
-	.irq      = IRQ_R_I2C,
+	.irqdev = &r_intc,
+	.irq    = IRQ_R_I2C,
 };
 
 static struct device r_intc = {
@@ -224,33 +221,30 @@ static struct device r_intc = {
 };
 
 static struct device r_pio = {
-	.name     = "r_pio",
-	.regs     = DEV_R_PIO,
-	.drv      = &sunxi_gpio_driver.drv,
-	.drvdata  = BIT(0), /**< Physically implemented ports (0). */
-	.clockdev = &r_ccu,
-	.clock    = R_CCU_CLOCK_R_PIO,
+	.name    = "r_pio",
+	.regs    = DEV_R_PIO,
+	.drv     = &sunxi_gpio_driver.drv,
+	.drvdata = BIT(0), /**< Physically implemented ports (0). */
+	.clocks  = CLOCK_PARENT(r_ccu, R_CCU_CLOCK_R_PIO),
 };
 
 static struct device r_timer0 = {
-	.name     = "r_timer0",
-	.regs     = DEV_R_TIMER,
-	.drv      = &sun8i_r_timer_driver.drv,
-	.drvdata  = 0, /**< Timer index within the device. */
-	.clockdev = &r_ccu,
-	.clock    = R_CCU_CLOCK_R_TIMER,
-	.irqdev   = &r_intc,
-	.irq      = IRQ_R_TIMER0,
+	.name    = "r_timer0",
+	.regs    = DEV_R_TIMER,
+	.drv     = &sun8i_r_timer_driver.drv,
+	.drvdata = 0, /**< Timer index within the device. */
+	.clocks  = CLOCK_PARENT(r_ccu, R_CCU_CLOCK_R_TIMER),
+	.irqdev  = &r_intc,
+	.irq     = IRQ_R_TIMER0,
 };
 
 static struct device r_twd = {
-	.name     = "r_twd",
-	.regs     = DEV_R_TWD,
-	.drv      = &sunxi_twd_driver.drv,
-	.clockdev = &r_ccu,
-	.clock    = R_CCU_CLOCK_R_TWD,
-	.irqdev   = &r_intc,
-	.irq      = IRQ_R_TWD,
+	.name   = "r_twd",
+	.regs   = DEV_R_TWD,
+	.drv    = &sunxi_twd_driver.drv,
+	.clocks = CLOCK_PARENT(r_ccu, R_CCU_CLOCK_R_TWD),
+	.irqdev = &r_intc,
+	.irq    = IRQ_R_TWD,
 };
 
 #if CONFIG_REGULATOR_SY8106A

--- a/platform/sun50i/devices.c
+++ b/platform/sun50i/devices.c
@@ -203,10 +203,10 @@ static struct device r_ccu = {
 };
 
 static struct device r_i2c = {
-	.name      = "r_i2c",
-	.regs      = DEV_R_I2C,
-	.drv       = &sun6i_a31_i2c_driver.drv,
-	.gpio_pins = GPIO_PINS(I2C_NUM_PINS) {
+	.name = "r_i2c",
+	.regs = DEV_R_I2C,
+	.drv  = &sun6i_a31_i2c_driver.drv,
+	.pins = GPIO_PINS(I2C_NUM_PINS) {
 		{ &r_pio, 0, 3 },
 		{ &r_pio, 1, 3 },
 	},


### PR DESCRIPTION
## Purpose

Move clock setup into a helper function that can handle multiple clocks per device. (The driver has to know how many clocks are needed.)

Needed for #53 

## Considerations for reviewers

I adjusted the neighboring GPIO function so they match.