### PR TITLE
SCPI Sensors/Regulators support

### DIFF
--- a/drivers/sensor/sun8i-thermal.c
+++ b/drivers/sensor/sun8i-thermal.c
@@ -49,6 +49,7 @@ static struct sun8i_thermal_sensor_info thermal_sensors[THS_SENSOR_COUNT] = {
 			.offset     = 223000,
 			.multiplier = -119,
 #endif
+			.class = SENSOR_CLASS_TEMPERATURE,
 		},
 		.address = THS0_DATA_REG,
 	},
@@ -58,6 +59,7 @@ static struct sun8i_thermal_sensor_info thermal_sensors[THS_SENSOR_COUNT] = {
 			.name       = "ths-cpu1",
 			.offset     = 259000,
 			.multiplier = -145,
+			.class      = SENSOR_CLASS_TEMPERATURE,
 		},
 		.address = THS1_DATA_REG,
 	},

--- a/drivers/sensor/sun8i-thermal.c
+++ b/drivers/sensor/sun8i-thermal.c
@@ -102,7 +102,7 @@ sun8i_thermal_probe(struct device *dev)
 	}
 #endif
 
-	/* Set aquire times to 0.1ms. */
+	/* Set acquire times to 0.1ms. */
 	mmio_write32(dev->regs + THS_CTL_REG0, 0x257);
 	mmio_write32(dev->regs + THS_CTL_REG2, 0x257 << 16);
 

--- a/include/drivers/sensor.h
+++ b/include/drivers/sensor.h
@@ -15,10 +15,25 @@
 #define SENSOR_OPS(dev) \
 	(&container_of((dev)->drv, struct sensor_driver, drv)->ops)
 
+enum {
+	SENSOR_CLASS_TEMPERATURE,
+	SENSOR_CLASS_VOLTAGE,
+	SENSOR_CLASS_CURRENT,
+	SENSOR_CLASS_POWER,
+	SENSOR_CLASS_ENERGY,
+};
+
+enum {
+	SENSOR_PERIODIC = BIT(0),
+	SENSOR_BOUNDS   = BIT(1),
+};
+
 struct sensor_info {
 	const char *const name;       /**< Name exported to SCPI. */
 	const int32_t     offset;     /**< Additive factor in millicelsius.*/
 	const int32_t     multiplier; /**< Multiplicative factor. */
+	const uint8_t     class;      /**< Sensor class (measured unit). */
+	const uint8_t     flags;      /**< Sensor trigger flags. */
 };
 
 struct sensor_driver_ops {


### PR DESCRIPTION
## Purpose

Implement SCPI sensor reading, so the THS can show up in Linux. Also implement PSU reading/writing.

Closes #49, Closes #48.

## Considerations for reviewers

A related bugfix is included.