### PR TITLE
drivers: regulator: axp803: Fix setting default values

### DIFF
--- a/drivers/regulator/axp803.c
+++ b/drivers/regulator/axp803.c
@@ -500,10 +500,9 @@ axp_regulator_probe(struct device *dev)
 		return err;
 	if ((err = axp803_match_type(dev)))
 		return err;
+	dev->subdev_count = AXP803_REGL_COUNT;
 	if ((err = regulator_set_defaults(dev, (uint16_t *)dev->drvdata)))
 		return err;
-
-	dev->subdev_count = AXP803_REGL_COUNT;
 
 	return SUCCESS;
 }


### PR DESCRIPTION
regulator_set_defaults uses the subdevice count to determine how many
regulators to initialize (which is equal to the number of entries in the
array of default voltages). Make sure this is initialized before calling
the function; otherwise, only the first regulator has its voltage set.