### PR TITLE
GCC 9 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ CC		 = $(CROSS_COMPILE)gcc
 CPP		 = $(CROSS_COMPILE)cpp
 OBJCOPY		 = $(CROSS_COMPILE)objcopy
 
+HAVE_GCC9	:= $(findstring version 9,$(shell $(CC) -v 2>&1;:))
+
 WARNINGS	 = -Wall -Wextra -Wformat=2 -Wpedantic -Wshadow \
 		   -Werror=implicit-function-declaration \
 		   -Werror=implicit-int \
@@ -29,7 +31,7 @@ CFLAGS		 = -Os -pipe -std=c11 \
 		   -fomit-frame-pointer \
 		   -funsigned-char \
 		   -g$(if $(filter-out 0,$(DEBUG)),gdb,0) \
-		   -mdelay -mhard-mul -msoft-float \
+		   -mhard-mul $(if $(HAVE_GCC9),-msext -msfimm -mshftimm) \
 		   -static \
 		   -Wa,--fatal-warnings \
 		   $(WARNINGS)

--- a/common/debug.c
+++ b/common/debug.c
@@ -109,6 +109,7 @@ conversion:
 			print_string("0x");
 			width = 2 * sizeof(arg);
 			zero  = true;
+		/* falls through */
 		case 'x':
 			print_hex(width, zero, arg);
 			break;

--- a/include/lib/macros.S
+++ b/include/lib/macros.S
@@ -12,6 +12,7 @@
 	.section .data.\name, "aw", @progbits
 	.global \name
 	.type \name, %object
+	.align 4
 \name:
 	.endm
 


### PR DESCRIPTION
## Purpose

- Fixes an alignment issue exposed by gcc9.
- Updates CFLAGS for gcc9.
- Silences a new warning in gcc9.

## Considerations for reviewers

Only change in the final binary on gcc5 is the order of symbols in `.data`, since the alignment of `console_base` changes from 1 to 4.