### PR TITLE
scpi: Bump the firmware version to 0.1

### DIFF
--- a/common/scpi_cmds.c
+++ b/common/scpi_cmds.c
@@ -75,7 +75,7 @@ static uint32_t scpi_cmd_get_scp_cap_tx_payload[] = {
 	/* Payload size limits. */
 	SCPI_PAYLOAD_LIMITS(SCPI_PAYLOAD_SIZE, SCPI_PAYLOAD_SIZE),
 	/* Firmware version. */
-	SCP_FIRMWARE_VERSION(0, 0, 0),
+	SCP_FIRMWARE_VERSION(0, 1, 0),
 	/* Commands enabled 0. */
 	BIT(SCPI_CMD_SCP_READY) |
 	BIT(SCPI_CMD_GET_SCP_CAP) |


### PR DESCRIPTION
This commit marks the branch point for the "legacy" proof-of-concept
Crust 0.1 that tries to implement and expose as much of the SCPI
specification as possible. This version of Crust follows an ABI (load
address, SCPI shared memory address, and mailbox channel assignment)
that is different from what will hopefully be merged into mainline Linux
and ATF.