### PR TITLE
Move watchdog_driver{,_ops} to a private header

### DIFF
--- a/drivers/watchdog/Makefile
+++ b/drivers/watchdog/Makefile
@@ -4,3 +4,4 @@
 #
 
 obj-y += sunxi-twd.o
+obj-y += watchdog.o

--- a/drivers/watchdog/sunxi-twd.c
+++ b/drivers/watchdog/sunxi-twd.c
@@ -4,12 +4,15 @@
  */
 
 #include <error.h>
+#include <intrusive.h>
 #include <mmio.h>
 #include <util.h>
 #include <watchdog.h>
 #include <clock/ccu.h>
 #include <watchdog/sunxi-twd.h>
 #include <platform/devices.h>
+
+#include "watchdog.h"
 
 #define TWD_STATUS_REG  0x00
 #define TWD_CTRL_REG    0x10

--- a/drivers/watchdog/watchdog.c
+++ b/drivers/watchdog/watchdog.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017-2020 The Crust Firmware Authors.
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
+ */
+
+#include <device.h>
+#include <intrusive.h>
+#include <stdint.h>
+
+#include "watchdog.h"
+
+/**
+ * Get the ops for the watchdog controller device.
+ */
+static inline const struct watchdog_driver_ops *
+watchdog_ops_for(const struct device *dev)
+{
+	const struct watchdog_driver *drv =
+		container_of(dev->drv, const struct watchdog_driver, drv);
+
+	return &drv->ops;
+}
+
+void
+watchdog_disable(const struct device *dev)
+{
+	watchdog_ops_for(dev)->disable(dev);
+}
+
+int
+watchdog_enable(const struct device *dev, uint32_t timeout)
+{
+	return watchdog_ops_for(dev)->enable(dev, timeout);
+}
+
+void
+watchdog_restart(const struct device *dev)
+{
+	watchdog_ops_for(dev)->restart(dev);
+}

--- a/drivers/watchdog/watchdog.h
+++ b/drivers/watchdog/watchdog.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017-2020 The Crust Firmware Authors.
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
+ */
+
+#ifndef WATCHDOG_PRIVATE_H
+#define WATCHDOG_PRIVATE_H
+
+#include <device.h>
+#include <stdint.h>
+
+struct watchdog_driver_ops {
+	void (*disable)(const struct device *dev);
+	int  (*enable)(const struct device *dev, uint32_t timeout);
+	void (*restart)(const struct device *dev);
+};
+
+struct watchdog_driver {
+	struct driver              drv;
+	struct watchdog_driver_ops ops;
+};
+
+#endif /* WATCHDOG_PRIVATE_H */

--- a/include/drivers/watchdog.h
+++ b/include/drivers/watchdog.h
@@ -7,33 +7,14 @@
 #define DRIVERS_WATCHDOG_H
 
 #include <device.h>
-#include <intrusive.h>
 #include <stdint.h>
-
-#define WATCHDOG_OPS(dev) \
-	(&container_of((dev)->drv, const struct watchdog_driver, drv)->ops)
-
-struct watchdog_driver_ops {
-	void (*disable)(const struct device *dev);
-	int  (*enable)(const struct device *dev, uint32_t timeout);
-	void (*restart)(const struct device *dev);
-};
-
-struct watchdog_driver {
-	struct driver              drv;
-	struct watchdog_driver_ops ops;
-};
 
 /**
  * Disable the watchdog.
  *
  * @param dev The watchdog device.
  */
-static inline void
-watchdog_disable(const struct device *dev)
-{
-	WATCHDOG_OPS(dev)->disable(dev);
-}
+void watchdog_disable(const struct device *dev);
 
 /**
  * Enable and restart the watchdog.
@@ -41,21 +22,13 @@ watchdog_disable(const struct device *dev)
  * @param dev     The watchdog device.
  * @param timeout The watchdog timeout in clock cycles.
  */
-static inline int
-watchdog_enable(const struct device *dev, uint32_t timeout)
-{
-	return WATCHDOG_OPS(dev)->enable(dev, timeout);
-}
+int watchdog_enable(const struct device *dev, uint32_t timeout);
 
 /**
  * Restart the watchdog. This must be called before the watchdog times out.
  *
  * @param dev The watchdog device.
  */
-static inline void
-watchdog_restart(const struct device *dev)
-{
-	WATCHDOG_OPS(dev)->restart(dev);
-}
+void watchdog_restart(const struct device *dev);
 
 #endif /* DRIVERS_WATCHDOG_H */


### PR DESCRIPTION
This is a partial fix for issue: #171
"Remove static inline wrappers from driver headers"

Signed-off-by: Vincent Legoll <vincent.legoll@gmail.com>
