### PR TITLE
Move msgbox_driver{,_ops} to a private header

### DIFF
--- a/drivers/msgbox/Makefile
+++ b/drivers/msgbox/Makefile
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
 #
 
+obj-y += msgbox.o
 obj-y += sunxi-msgbox.o

--- a/drivers/msgbox/msgbox.c
+++ b/drivers/msgbox/msgbox.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017-2020 The Crust Firmware Authors.
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
+ */
+
+#include <device.h>
+#include <intrusive.h>
+#include <msgbox.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "msgbox.h"
+
+/**
+ * Get the ops for the msgbox controller device.
+ */
+static inline const struct msgbox_driver_ops *
+msgbox_ops_for(const struct device *dev)
+{
+	const struct msgbox_driver *drv =
+		container_of(dev->drv, const struct msgbox_driver, drv);
+
+	return &drv->ops;
+}
+
+void
+msgbox_ack_rx(const struct device *dev, uint8_t chan)
+{
+	msgbox_ops_for(dev)->ack_rx(dev, chan);
+}
+
+bool
+msgbox_last_tx_done(const struct device *dev, uint8_t chan)
+{
+	return msgbox_ops_for(dev)->last_tx_done(dev, chan);
+}
+
+int
+msgbox_receive(const struct device *dev, uint8_t chan, uint32_t *message)
+{
+	return msgbox_ops_for(dev)->receive(dev, chan, message);
+}
+
+int
+msgbox_send(const struct device *dev, uint8_t chan, uint32_t message)
+{
+	return msgbox_ops_for(dev)->send(dev, chan, message);
+}

--- a/drivers/msgbox/msgbox.h
+++ b/drivers/msgbox/msgbox.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017-2020 The Crust Firmware Authors.
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
+ */
+
+#ifndef MSGBOX_PRIVATE_H
+#define MSGBOX_PRIVATE_H
+
+#include <device.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+struct msgbox_driver_ops {
+	void (*ack_rx)(const struct device *dev, uint8_t chan);
+	bool (*last_tx_done)(const struct device *dev, uint8_t chan);
+	int  (*receive)(const struct device *dev, uint8_t chan,
+	                uint32_t *message);
+	int  (*send)(const struct device *dev, uint8_t chan,
+	             uint32_t message);
+};
+
+struct msgbox_driver {
+	struct driver            drv;
+	struct msgbox_driver_ops ops;
+};
+
+#endif /* MSGBOX_PRIVATE_H */

--- a/drivers/msgbox/sunxi-msgbox.c
+++ b/drivers/msgbox/sunxi-msgbox.c
@@ -6,6 +6,7 @@
 #include <debug.h>
 #include <device.h>
 #include <error.h>
+#include <intrusive.h>
 #include <mmio.h>
 #include <msgbox.h>
 #include <stdbool.h>
@@ -14,6 +15,8 @@
 #include <clock/ccu.h>
 #include <msgbox/sunxi-msgbox.h>
 #include <platform/devices.h>
+
+#include "msgbox.h"
 
 #define CTRL_REG0           0x0000
 #define CTRL_REG1           0x0004

--- a/include/drivers/msgbox.h
+++ b/include/drivers/msgbox.h
@@ -7,26 +7,8 @@
 #define DRIVERS_MSGBOX_H
 
 #include <device.h>
-#include <intrusive.h>
 #include <stdbool.h>
 #include <stdint.h>
-
-#define MSGBOX_OPS(dev) \
-	(&container_of((dev)->drv, const struct msgbox_driver, drv)->ops)
-
-struct msgbox_driver_ops {
-	void (*ack_rx)(const struct device *dev, uint8_t chan);
-	bool (*last_tx_done)(const struct device *dev, uint8_t chan);
-	int  (*receive)(const struct device *dev, uint8_t chan,
-	                uint32_t *message);
-	int  (*send)(const struct device *dev, uint8_t chan,
-	             uint32_t message);
-};
-
-struct msgbox_driver {
-	struct driver            drv;
-	struct msgbox_driver_ops ops;
-};
 
 /**
  * Acknowledge a message received on a message box channel.
@@ -34,11 +16,7 @@ struct msgbox_driver {
  * @param dev  The message box device.
  * @param chan The message box channel.
  */
-static inline void
-msgbox_ack_rx(const struct device *dev, uint8_t chan)
-{
-	MSGBOX_OPS(dev)->ack_rx(dev, chan);
-}
+void msgbox_ack_rx(const struct device *dev, uint8_t chan);
 
 /**
  * Check if the last transmission on a message box channel has completed, or if
@@ -48,11 +26,7 @@ msgbox_ack_rx(const struct device *dev, uint8_t chan)
  * @param dev  The message box device.
  * @param chan The message box channel.
  */
-static inline bool
-msgbox_last_tx_done(const struct device *dev, uint8_t chan)
-{
-	return MSGBOX_OPS(dev)->last_tx_done(dev, chan);
-}
+bool msgbox_last_tx_done(const struct device *dev, uint8_t chan);
 
 /**
  * Receive a message via a message box channel.
@@ -61,11 +35,7 @@ msgbox_last_tx_done(const struct device *dev, uint8_t chan)
  * @param chan    The channel to use within the message box.
  * @param message The message to receive.
  */
-static inline int
-msgbox_receive(const struct device *dev, uint8_t chan, uint32_t *message)
-{
-	return MSGBOX_OPS(dev)->receive(dev, chan, message);
-}
+int msgbox_receive(const struct device *dev, uint8_t chan, uint32_t *message);
 
 /**
  * Send a message via a message box channel.
@@ -74,10 +44,6 @@ msgbox_receive(const struct device *dev, uint8_t chan, uint32_t *message)
  * @param chan    The channel to use within the message box.
  * @param message The message to send.
  */
-static inline int
-msgbox_send(const struct device *dev, uint8_t chan, uint32_t message)
-{
-	return MSGBOX_OPS(dev)->send(dev, chan, message);
-}
+int msgbox_send(const struct device *dev, uint8_t chan, uint32_t message);
 
 #endif /* DRIVERS_MSGBOX_H */

--- a/include/drivers/msgbox/sunxi-msgbox.h
+++ b/include/drivers/msgbox/sunxi-msgbox.h
@@ -7,7 +7,9 @@
 #define DRIVERS_MSGBOX_SUNXI_MSGBOX_H
 
 #include <clock.h>
+#include <device.h>
 #include <msgbox.h>
+#include <stdint.h>
 
 /* The message box hardware provides 8 unidirectional channels. */
 #define SUNXI_MSGBOX_CHANS 8


### PR DESCRIPTION
This is a partial fix for issue: #171
"Remove static inline wrappers from driver headers"

Signed-off-by: Vincent Legoll <vincent.legoll@gmail.com>