### PR TITLE
build: Drop implicit-fallthrough to allow older build compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ COMMON_CFLAGS	 = -Os -pipe -std=c11 \
 		   -fvar-tracking-assignments \
 		   -g$(if $(CONFIG_DEBUG_INFO),gdb,0) \
 		   -Wall -Wextra -Wformat=2 -Wpedantic -Wshadow \
-		   -Werror=implicit-fallthrough=5 \
 		   -Werror=implicit-function-declaration \
 		   -Werror=implicit-int \
 		   -Werror=pointer-arith \
@@ -54,7 +53,7 @@ BUILDCPPFLAGS	 = $(COMMON_CPPFLAGS) \
 BUILDLDFLAGS	 =
 BUILDLDLIBS	 =
 
-HOSTCFLAGS	 = $(COMMON_CFLAGS)
+HOSTCFLAGS	 = $(COMMON_CFLAGS) -Werror=implicit-fallthrough=5
 HOSTCPPFLAGS	 = $(COMMON_CPPFLAGS) \
 		   -D_XOPEN_SOURCE=700
 HOSTLDFLAGS	 =
@@ -62,6 +61,7 @@ HOSTLDLIBS	 =
 
 AFLAGS		 = -Wa,--fatal-warnings
 CFLAGS		 = $(COMMON_CFLAGS) \
+		   -Werror=implicit-fallthrough=5 \
 		   -ffixed-r2 \
 		   -ffreestanding \
 		   -flto \


### PR DESCRIPTION
-Wimplicit-fallthrough was introduced in GCC 7, so currently building
crust requires all three involved compilers to be at least of that
vintage.

While it's somewhat feasible to upgrade to a newer *cross*-compiler, the
system compiler is much harder to update on its own, especially in long
term stable distributions.

To allow building crust on older Linux systems without extended surgery,
drop the new warning option from the "build" compiler flavour.
Actually it is explicitly disabled again when building Kconfig, so we
don't really lose anything.

Signed-off-by: Andre Przywara <andre.przywara@arm.com>

<!-- Thank you for contributing to Crust firmware!

Pull requests that do not follow the guidelines outlined in the Crust firmware
contribution guidelines are subject to immediate rejection! -->

## Purpose
<!-- Please include the purpose of changes included in this pull request. -->

<!-- Please add the issue number of the issue this pull request addresses. If
this pull request addresses multiple issues, please add them as a
comma-separated list (i.e. Closes #1, Closes #2, Fixes #3).

NOTE: when submitting a bug fix, please uses "Fixes" rather than "Closes" -->
Closes #

## Considerations for reviewers
<!-- (Optional) Include considerations or notes for project maintainers and
reviewers.  -->
