### PR TITLE
drivers: cir: fix rc6 margins

### DIFF
--- a/drivers/cir/rc6.c
+++ b/drivers/cir/rc6.c
@@ -48,7 +48,8 @@ uint32_t
 cir_decode(struct cir_dec_ctx *ctx)
 {
 	int32_t duration = rc6_durations[ctx->state];
-	int32_t epsilon  = duration >> 1;
+	int32_t epsilon  = ctx->state == RC6_IDLE ?
+		RC6_UNITS_TO_CLKS(1) : RC6_UNITS_TO_CLKS(1) / 2;
 
 	/* Subtract the expected pulse with from the sample width. */
 	ctx->width -= duration;


### PR DESCRIPTION
## Purpose

Now that time constants are calculated more precisely, rc6 decoding is
not reliable as before. Mostly it fails in trailer states (4 and 5).

It turns out that epsilon is too big in those states. Consider
transition from RC6_TRAILER_N to RC6_DATA_P. Current epsilon calculation
makes epsilon in RC6_TRAILER_N the same size as the duration of pulse in
RC6_DATA_N. Obviously this means that RC6_TRAILER_N pulse may be eaten
and decoding fails.

Fix that by making idle state epsilon a bit larger, but keep epsilon at
half of time unit for all other states.

Tested on A64 (OrangePi Win) and H6 (OrangePi 3), with IR on osc24m and
osc32k.

Signed-off-by: Jernej Skrabec <jernej.skrabec@siol.net>

<!-- Thank you for contributing to Crust firmware!

Pull requests that do not follow the guidelines outlined in the Crust firmware
contribution guidelines are subject to immediate rejection! -->

<!-- Please include the purpose of changes included in this pull request. -->

<!-- Please add the issue number of the issue this pull request addresses. If
this pull request addresses multiple issues, please add them as a
comma-separated list (i.e. Closes #1, Closes #2, Fixes #3).

NOTE: when submitting a bug fix, please uses "Fixes" rather than "Closes" -->
Closes #
