### PR TITLE
configs: add PineTab defconfig

### DIFF
--- a/configs/pinetab_defconfig
+++ b/configs/pinetab_defconfig
@@ -1,0 +1,2 @@
+CONFIG_MFD_AXP20X=y
+# CONFIG_SERIAL is not set


### PR DESCRIPTION
## Purpose

This PR adds a defconfig for the PineTab, based on the PineBook config.