### PR TITLE
HDMI CEC wakeup support

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -6,6 +6,7 @@
 menu "Device drivers"
 
 source "dram/Kconfig"
+source "cec/Kconfig"
 source "cir/Kconfig"
 source "clock/Kconfig"
 source "regmap/Kconfig"

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
 #
 
+obj-$(CONFIG_CEC) += cec/
 obj-$(CONFIG_CIR) += cir/
 obj-y += clock/
 obj-y += css/

--- a/drivers/cec/Kconfig
+++ b/drivers/cec/Kconfig
@@ -1,0 +1,11 @@
+#
+# Copyright © 2021 The Crust Firmware Authors.
+# SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
+#
+
+config CEC
+	bool "HDMI CEC"
+	help
+		Listen for messages from TV or other devices on HDMI CEC bus.
+		This can be used as a wakeup source. Note: Clocks and resets
+		must be pre-initialized by rich OS.

--- a/drivers/cec/Makefile
+++ b/drivers/cec/Makefile
@@ -1,0 +1,8 @@
+#
+# Copyright © 2021 The Crust Firmware Authors.
+# SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
+#
+
+obj-y += cec.o
+
+obj-y += dw-hdmi-cec.o

--- a/drivers/cec/cec.c
+++ b/drivers/cec/cec.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2021 The Crust Firmware Authors.
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
+ */
+
+#include <cec.h>
+#include <device.h>
+#include <cec/dw-hdmi-cec.h>
+
+const struct device *
+cec_get(void)
+{
+	return device_get_or_null(&hdmi_cec.dev);
+}
+
+uint32_t
+cec_poll(const struct device *dev)
+{
+	if (!dev)
+		return 0;
+
+	return dw_hdmi_cec_poll(dev);
+}

--- a/drivers/cec/dw-hdmi-cec.c
+++ b/drivers/cec/dw-hdmi-cec.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2021 The Crust Firmware Authors.
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
+ */
+
+#include <error.h>
+#include <intrusive.h>
+#include <mmio.h>
+#include <util.h>
+#include <cec/dw-hdmi-cec.h>
+#include <clock/ccu.h>
+#include <platform/devices.h>
+
+#define CEC_STAT     0x0106
+#define CEC_MUTE     0x0186
+#define IH_MUTE      0x01ff
+#define CEC_CTRL     0x7d00
+#define CEC_MASK     0x7d02
+#define CEC_POL      0x7d03
+#define CEC_ADDRL    0x7d05
+#define CEC_ADDRH    0x7d06
+#define CEC_TX_CNT   0x7d07
+#define CEC_RX_CNT   0x7d08
+#define CEC_TX_DATA  0x7d10
+#define CEC_RX_DATA  0x7d20
+#define CEC_LOCK     0x7d30
+#define CEC_WKUPCTRL 0x7d31
+
+#define IRQ_WAKEUP       BIT(6)
+#define IRQ_ALL          0xff
+
+#define IH_MUTE_ALL      0x03
+
+#define CEC_CTRL_STANDBY BIT(4)
+
+#define CEC_LOCK_RELEASE 0x00
+
+/* Set Stream Path */
+#define CEC_WKUP_MSG_86  BIT(7)
+/* Active Source */
+#define CEC_WKUP_MSG_82  BIT(6)
+/* System Audio Mode Request */
+#define CEC_WKUP_MSG_70  BIT(5)
+/* User Control Pressed */
+#define CEC_WKUP_MSG_44  BIT(4)
+/* Deck Control */
+#define CEC_WKUP_MSG_42  BIT(3)
+/* Play */
+#define CEC_WKUP_MSG_41  BIT(2)
+/* Text View On */
+#define CEC_WKUP_MSG_0d  BIT(1)
+/* Image View On */
+#define CEC_WKUP_MSG_04  BIT(0)
+
+#define CEC_WKUP_MSG_ALL (CEC_WKUP_MSG_86 | CEC_WKUP_MSG_82 | \
+			  CEC_WKUP_MSG_70 | CEC_WKUP_MSG_44 | \
+			  CEC_WKUP_MSG_42 | CEC_WKUP_MSG_41 | \
+			  CEC_WKUP_MSG_0d | CEC_WKUP_MSG_04)
+
+struct dw_hdmi_cec_state {
+	struct device_state ds;
+	uint8_t             stash[4];
+};
+
+static inline const struct dw_hdmi_cec *
+to_dw_hdmi_cec(const struct device *dev)
+{
+	return container_of(dev, const struct dw_hdmi_cec, dev);
+}
+
+static inline struct dw_hdmi_cec_state *
+dw_hdmi_cec_state_for(const struct device *dev)
+{
+	return container_of(dev->state, struct dw_hdmi_cec_state, ds);
+}
+
+uint32_t
+dw_hdmi_cec_poll(const struct device *dev)
+{
+	const struct dw_hdmi_cec *self = to_dw_hdmi_cec(dev);
+	uint8_t stat;
+
+	stat = mmio_read_8(self->regs + CEC_STAT);
+	mmio_write_8(self->regs + CEC_STAT, stat);
+
+	return stat & IRQ_WAKEUP;
+}
+
+static int
+dw_hdmi_cec_probe(const struct device *dev)
+{
+	const struct dw_hdmi_cec *self = to_dw_hdmi_cec(dev);
+	struct dw_hdmi_cec_state *state = dw_hdmi_cec_state_for(dev);
+
+	clock_get(&self->bus_clock);
+
+	state->stash[0] = mmio_read_8(self->regs + CEC_MUTE);
+	state->stash[1] = mmio_read_8(self->regs + CEC_MASK);
+	state->stash[2] = mmio_read_8(self->regs + CEC_POL);
+	state->stash[3] = mmio_read_8(self->regs + IH_MUTE);
+
+	/* Mute all interrupts */
+	mmio_write_8(self->regs + IH_MUTE, IH_MUTE_ALL);
+
+	/* Configure CEC wake up sources */
+	mmio_write_8(self->regs + CEC_WKUPCTRL, CEC_WKUP_MSG_ALL);
+
+	/* Allow only wakeup interrupt on posedge */
+	mmio_write_8(self->regs + CEC_POL, IRQ_WAKEUP);
+	mmio_write_8(self->regs + CEC_MUTE, (uint8_t)~IRQ_WAKEUP);
+	mmio_write_8(self->regs + CEC_MASK, (uint8_t)~IRQ_WAKEUP);
+
+	/* Clear any pending interrupt */
+	mmio_write_8(self->regs + CEC_STAT, IRQ_ALL);
+
+	/* Release CEC message in RX buffer (if any) */
+	mmio_write_8(self->regs + CEC_LOCK, CEC_LOCK_RELEASE);
+
+	/*
+	 * Put CEC controller in automatic mode. It will NACK all messages
+	 * except those, which are allowed in CEC_WKUPCTRL register.
+	 */
+	mmio_write_8(self->regs + CEC_CTRL, CEC_CTRL_STANDBY);
+
+	/* Unmute interrupts */
+	mmio_write_8(self->regs + IH_MUTE, 0x00);
+
+	return SUCCESS;
+}
+
+static void
+dw_hdmi_cec_release(const struct device *dev)
+{
+	const struct dw_hdmi_cec *self = to_dw_hdmi_cec(dev);
+	struct dw_hdmi_cec_state *state = dw_hdmi_cec_state_for(dev);
+
+	/* Mute all interrupts */
+	mmio_write_8(self->regs + IH_MUTE, IH_MUTE_ALL);
+
+	/* Clear wake up sources */
+	mmio_write_8(self->regs + CEC_WKUPCTRL, 0x00);
+
+	/* Put controller out of automatic mode */
+	mmio_write_8(self->regs + CEC_CTRL, 0x00);
+
+	/* Clear any pending interrupt */
+	mmio_write_8(self->regs + CEC_STAT, IRQ_ALL);
+
+	/* Release CEC message in RX buffer (if any) */
+	mmio_write_8(self->regs + CEC_LOCK, CEC_LOCK_RELEASE);
+
+	/* restore registers */
+	mmio_write_8(self->regs + CEC_POL, state->stash[2]);
+	mmio_write_8(self->regs + CEC_MASK, state->stash[1]);
+	mmio_write_8(self->regs + CEC_MUTE, state->stash[0]);
+
+	/* Restoring IH_MUTE must be last, since it enables interrutps */
+	mmio_write_8(self->regs + IH_MUTE, state->stash[3]);
+
+	clock_put(&self->bus_clock);
+}
+
+static const struct driver dw_hdmi_cec_driver = {
+	.probe   = dw_hdmi_cec_probe,
+	.release = dw_hdmi_cec_release,
+};
+
+const struct dw_hdmi_cec hdmi_cec = {
+	.dev = {
+		.name  = "DW HDMI CEC",
+		.drv   = &dw_hdmi_cec_driver,
+		.state = &(struct dw_hdmi_cec_state) { { 0 } }.ds,
+	},
+	.bus_clock = { .dev = &r_ccu.dev, .id = CLK_OSC24M },
+	.regs = DEV_HDMI,
+};

--- a/include/drivers/cec.h
+++ b/include/drivers/cec.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2021 The Crust Firmware Authors.
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
+ */
+
+#ifndef DRIVERS_CEC_H
+#define DRIVERS_CEC_H
+
+#include <device.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#if CONFIG(CEC)
+
+/**
+ * Acquire a reference to the CEC receiver device suitable for polling.
+ *
+ * The reference must be released before resuming the rich OS.
+ *
+ * @return    A reference to the CEC receiver device.
+ */
+const struct device *cec_get(void);
+
+/**
+ * Check the CEC receiver for a wakeup condition.
+ *
+ * @param dev A reference to the CEC receiver device.
+ * @return    Nonzero if the system should wake up, else zero.
+ */
+uint32_t cec_poll(const struct device *dev);
+
+#else
+
+static inline const struct device *
+cec_get(void)
+{
+	return NULL;
+}
+
+static inline uint32_t
+cec_poll(const struct device *dev UNUSED)
+{
+	return 0;
+}
+
+#endif
+
+#endif /* DRIVERS_CEC_H */

--- a/include/drivers/cec/dw-hdmi-cec.h
+++ b/include/drivers/cec/dw-hdmi-cec.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2021 The Crust Firmware Authors.
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
+ */
+
+#ifndef DRIVERS_CEC_DW_HDMI_CEC_H
+#define DRIVERS_CEC_DW_HDMI_CEC_H
+
+#include <clock.h>
+#include <device.h>
+#include <stdint.h>
+
+struct dw_hdmi_cec {
+	struct device       dev;
+	struct clock_handle bus_clock;
+	uintptr_t           regs;
+};
+
+extern const struct dw_hdmi_cec hdmi_cec;
+
+uint32_t dw_hdmi_cec_poll(const struct device *dev);
+
+#endif /* DRIVERS_CEC_DW_HDMI_CEC_H */

--- a/include/lib/mmio.h
+++ b/include/lib/mmio.h
@@ -115,6 +115,20 @@ mmio_read_32(uintptr_t addr)
 }
 
 /**
+ * Read a 8-bit MMIO register.
+ *
+ * @param addr The address of the register.
+ * @return     The value of the register.
+ */
+static inline uint8_t
+mmio_read_8(uintptr_t addr)
+{
+	volatile uint8_t *ptr = (void *)(addr ^ 3);
+
+	return *ptr;
+}
+
+/**
  * Set bits in a 32-bit MMIO register.
  *
  * @param addr The address of the register.
@@ -138,6 +152,20 @@ static inline void
 mmio_write_32(uintptr_t addr, uint32_t val)
 {
 	volatile uint32_t *ptr = (void *)addr;
+
+	*ptr = val;
+}
+
+/**
+ * Write a 8-bit MMIO register.
+ *
+ * @param addr The address of the register.
+ * @param val  The new value of the register.
+ */
+static inline void
+mmio_write_8(uintptr_t addr, uint8_t val)
+{
+	volatile uint8_t *ptr = (void *)(addr ^ 3);
 
 	*ptr = val;
 }


### PR DESCRIPTION
<!-- Please include the purpose of changes included in this pull request. -->
## Purpose
This PR implements DW HDMI CEC driver, which can be used as a wakeup source. It assumes that clocks and resets are already initialized by rich OS.

Note that it's very important that CEC has stable 32 kHz clock source. On A64, H3 and H5 this means external 32 kHz crystal (RC oscillator is too unstable). On H6, CEC peripheral is usually clocked from pll-periph0-2x with fixed predivider.

<!-- (Optional) Include considerations or notes for project maintainers and
reviewers.  -->
## Considerations for reviewers
It was tested on A64 only for now. It should work on H3 and H5 too, since they have same DW HDMI controller and PHY. There is no reason why it shouldn't work on H6 too, but due to a newer controller and different PHY it might not work correctly yet.

<!-- Please add the number of the issue this pull request addresses. If this
pull request addresses multiple issues, please add them as a comma-separated
list (i.e. Closes #1, Closes #2, Fixes #3). -->
Closes #196