### PR TITLE
Makefile: allow override of BUILDCC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OBJ		 = build
 TGT		 = $(OBJ)/scp
 
 BUILDAR		 = ar
-BUILDCC		 = cc
+BUILDCC		?= cc
 
 HOST_COMPILE	?= aarch64-linux-musl-
 HOSTAR		 = $(HOST_COMPILE)gcc-ar


### PR DESCRIPTION
<!-- Please include the purpose of changes included in this pull request. -->
## Purpose
Allow BUILDCC to be overridden, as crust build fails when cc is missing (e.g. minimal Ubuntu 20.04)

<!-- (Optional) Include considerations or notes for project maintainers and
reviewers.  -->
## Considerations for reviewers
Issue identified in LibreELEC builds with the minimal focal 20.04 docker. `cc` is not available. Patch currently in place - https://github.com/LibreELEC/LibreELEC.tv/pull/5953 - but better solution is to allow `BUILDCC` to be overridden and use the toolchain compiler (not the Operating System supplied `cc` compiler.)

<!-- Please add the number of the issue this pull request addresses. If this
pull request addresses multiple issues, please add them as a comma-separated
list (i.e. Closes #1, Closes #2, Fixes #3). -->
Error log
```
BUILD      crust (target)
    TOOLCHAIN      manual
...
  HOSTCC  build/3rdparty/kconfig/conf.o
/bin/sh: 1: exec: cc: not found
make[1]: *** [Makefile:170: build/3rdparty/kconfig/conf.o] Error 127
...
```