### PR TITLE
Fix build using GCC 12.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ LDFLAGS		 = -nostdlib \
 		   -static \
 		   -Wl,-O1 \
 		   -Wl,--build-id=none \
+		   -Wl,--no-warn-rwx-segments \
 		   -Wl,--fatal-warnings \
 		   -Wl,--gc-sections \
 		   -Wl,--no-dynamic-linker \


### PR DESCRIPTION
I have linking error like the following:
```
|   LD      .../crust/2022.09.13-r0/build/scp/scp.elf
| .../crust/2022.09.13-r0/recipe-sysroot-native/usr/bin/../lib/gcc/or1k-none-elf/12.2.0/../../../../or1k-none-elf/bin/ld: warning: .../crust/2022.09.13-r0/build/scp/scp.elf has a LOAD segment with RWX permissions
| collect2: error: ld returned 1 exit status
| make: *** [Makefile:197: .../crust/2022.09.13-r0/build/scp/scp.elf] Error 1
| make: Leaving directory '.../crust/2022.09.13-r0/git'
```

<!-- Please include the purpose of changes included in this pull request. -->
## Purpose

<!-- (Optional) Include considerations or notes for project maintainers and
reviewers.  -->
## Considerations for reviewers

<!-- Please add the number of the issue this pull request addresses. If this
pull request addresses multiple issues, please add them as a comma-separated
list (i.e. Closes #1, Closes #2, Fixes #3). -->
Closes #
